### PR TITLE
Create a preview for each pull request

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,6 +22,8 @@ steps:
         from_secret: developer_host
       sftp_user:
         from_secret: sftp_user
+      GITHUB_TOKEN:
+        from_secret: github_token
     commands:
       - mkdir -p ~/.ssh
       - eval $(ssh-agent -s)

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,8 +32,6 @@ steps:
       - rclone config create server sftp host $developer_host user $sftp_user port 22
       - rclone --dry-run -v sync build server:$TARGET
     when:
-      branch:
-        - main
       status:
         - success
       event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -30,7 +30,8 @@ steps:
       - chmod 600 ~/.ssh/id_rsa
       - ssh-add
       - rclone config create server sftp host $developer_host user $sftp_user port 22
-      - if [ -z "$${DRONE_PULL_REQUEST}" ]; then; export TARGET=public_html; else; export TARGET=wildcard.manual.joomlacode.org/sites/pr-$${DRONE_PULL_REQUEST}"; endif
+      - if [ -z "$${DRONE_PULL_REQUEST}" ]; then export TARGET=public_html; else export TARGET=wildcard.manual.joomlacode.org/sites/pr-$${DRONE_PULL_REQUEST}; fi
+      - eval $${TARGET}
       - rclone --dry-run -v sync build server:$TARGET
     when:
       status:

--- a/.drone.yml
+++ b/.drone.yml
@@ -31,7 +31,6 @@ steps:
       - ssh-add
       - rclone config create server sftp host $developer_host user $sftp_user port 22
       - if [ -z "$${DRONE_PULL_REQUEST}" ]; then export TARGET=public_html; else export TARGET=wildcard.manual.joomlacode.org/sites/pr-$${DRONE_PULL_REQUEST}; fi
-      - eval $${TARGET}
       - rclone --dry-run -v sync build server:$TARGET
     when:
       status:

--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ steps:
   - name: deployment
     image: joomlaprojects/docker-images:packager
     depends_on:
-     - build
+      - build
     environment:
       REMOTE_PRIVATE_KEY:
         from_secret: REMOTE_PRIVATE_KEY
@@ -35,8 +35,7 @@ steps:
       - if [ -z "$${DRONE_PULL_REQUEST}" ]; then export TARGET=public_html; else export TARGET=wildcard.manual.joomlacode.org/sites/pr-$${DRONE_PULL_REQUEST}; fi
       - rclone -v sync build server:$TARGET
       - chmod +x test.sh
-      - if [ ! -z "$${DRONE_PULL_REQUEST}" ]; then ./test.sh "Preview" "Generated preview for this pull request" "http://$${TARGET}" ; fi;
-
+      - if [ ! -z "$${DRONE_PULL_REQUEST}" ]; then /bin/add_github_status.sh "Preview" "Generated preview for this pull request" "http://pr-$${DRONE_PULL_REQUEST}.manual.joomlacode.org" ; fi;
     when:
       branch:
         main
@@ -48,6 +47,6 @@ steps:
 
 ---
 kind: signature
-hmac: 348c8ac11879e5515a5b167c9af1a7d6bba2f3bd66408a291f4f9f6ff27d8204
+hmac: 3d1303abd175ffda3aec141c6ea71d541f50f3c3e0752a68330fde5560386a58
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -31,7 +31,7 @@ steps:
       - ssh-add
       - rclone config create server sftp host $developer_host user $sftp_user port 22
       - if [ -z "$${DRONE_PULL_REQUEST}" ]; then export TARGET=public_html; else export TARGET=wildcard.manual.joomlacode.org/sites/pr-$${DRONE_PULL_REQUEST}; fi
-      - rclone --dry-run -v sync build server:$TARGET
+      - rclone -v sync build server:$TARGET
       - chmod +x test.sh
       - if [ ! -z "$${DRONE_PULL_REQUEST}" ]; then ./test.sh "Preview" "Generated preview for this pull request" "http://$${TARGET}" ; fi;
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,16 +5,16 @@ name: default
 clone:
 
 steps:
-#  - name: build
-#    image: node:18-bullseye-slim
-#    commands:
-#      - npm install
-#      - npm run build
+  - name: build
+    image: node:18-bullseye-slim
+    commands:
+      - npm install
+      - npm run build
 
   - name: deployment
     image: joomlaprojects/docker-images:packager
-#    depends_on:
-#     - build
+    depends_on:
+     - build
     environment:
       REMOTE_PRIVATE_KEY:
         from_secret: REMOTE_PRIVATE_KEY

--- a/.drone.yml
+++ b/.drone.yml
@@ -33,6 +33,8 @@ steps:
       - if [ -z "$${DRONE_PULL_REQUEST}" ]; then export TARGET=public_html; else export TARGET=wildcard.manual.joomlacode.org/sites/pr-$${DRONE_PULL_REQUEST}; fi
       - rclone --dry-run -v sync build server:$TARGET
     when:
+      branch:
+        main
       status:
         - success
       event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,11 +5,11 @@ name: default
 clone:
 
 steps:
-  - name: build
-    image: node:18-bullseye-slim
-    commands:
-      - npm install
-      - npm run build
+#  - name: build
+#    image: node:18-bullseye-slim
+#    commands:
+#      - npm install
+#      - npm run build
 
   - name: deployment
     image: joomlaprojects/docker-images:packager
@@ -30,7 +30,7 @@ steps:
       - chmod 600 ~/.ssh/id_rsa
       - ssh-add
       - rclone config create server sftp host $developer_host user $sftp_user port 22
-      - if [ -z "$${DRONE_PULL_REQUEST}" ]; export TARGET=public_html; endif
+      - if [ -z "$${DRONE_PULL_REQUEST}" ]; then; export TARGET=public_html; else; export TARGET=wildcard.manual.joomlacode.org/sites/pr-$${DRONE_PULL_REQUEST}"; endif
       - rclone --dry-run -v sync build server:$TARGET
     when:
       status:

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,8 +13,8 @@ steps:
 
   - name: deployment
     image: joomlaprojects/docker-images:packager
-    depends_on:
-      - build
+#    depends_on:
+#     - build
     environment:
       REMOTE_PRIVATE_KEY:
         from_secret: REMOTE_PRIVATE_KEY

--- a/.drone.yml
+++ b/.drone.yml
@@ -32,6 +32,9 @@ steps:
       - rclone config create server sftp host $developer_host user $sftp_user port 22
       - if [ -z "$${DRONE_PULL_REQUEST}" ]; then export TARGET=public_html; else export TARGET=wildcard.manual.joomlacode.org/sites/pr-$${DRONE_PULL_REQUEST}; fi
       - rclone --dry-run -v sync build server:$TARGET
+      - chmod +x test.sh
+      - if [ ! -z "$${DRONE_PULL_REQUEST}" ]; then ./test.sh "Preview" "Generated preview for this pull request" "http://$${TARGET}" ; fi;
+
     when:
       branch:
         main

--- a/.drone.yml
+++ b/.drone.yml
@@ -30,7 +30,6 @@ steps:
       - chmod 600 ~/.ssh/id_rsa
       - ssh-add
       - rclone config create server sftp host $developer_host user $sftp_user port 22
-      - "[ -z "$${DRONE_PULL_REQUEST}" ] && export TARGET=public_html || export TARGET=wildcard.manual.joomlacode.org/sites/pr-$${DRONE_PULL_REQUEST}"
       - rclone --dry-run -v sync build server:$TARGET
     when:
       branch:

--- a/.drone.yml
+++ b/.drone.yml
@@ -30,6 +30,7 @@ steps:
       - chmod 600 ~/.ssh/id_rsa
       - ssh-add
       - rclone config create server sftp host $developer_host user $sftp_user port 22
+      - if [ -z "$${DRONE_PULL_REQUEST}" ]; export TARGET=public_html; endif
       - rclone --dry-run -v sync build server:$TARGET
     when:
       status:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ $ npm run build
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
 
+### Preview for pull request
 
+As part of the documentation validation we create a subdomain for previewing your pull request.
+The Link will be added to the "checks" section in the pull request as "preview". The url used
+is http://pr-[prnumber].manual.joomlacode.org
 
 ## How to use
 

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+HEADLINE="$1"
+DESCRIPTION="$2"
+TARGETURL="$3"
+
+if [ -z "$TARGETURL" ];
+then
+  echo "Headline, description and targeturl is need."
+  exit 1
+fi
+
+curl -X POST "https://api.github.com/repos/$DRONE_REPO/statuses/$DRONE_COMMIT" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -d "{\"state\": \"success\", \"context\": \"$HEADLINE\", \"description\": \"DESCRIPTION\", \"target_url\": \"TARGETURL\"}" > /dev/null

--- a/test.sh
+++ b/test.sh
@@ -13,4 +13,4 @@ fi
 curl -X POST "https://api.github.com/repos/$DRONE_REPO/statuses/$DRONE_COMMIT" \
   -H "Content-Type: application/json" \
   -H "Authorization: token $GITHUB_TOKEN" \
-  -d "{\"state\": \"success\", \"context\": \"$HEADLINE\", \"description\": \"DESCRIPTION\", \"target_url\": \"TARGETURL\"}" > /dev/null
+  -d "{\"state\": \"success\", \"context\": \"$HEADLINE\", \"description\": \"$DESCRIPTION\", \"target_url\": \"$TARGETURL\"}" > /dev/null


### PR DESCRIPTION
This PR uploads each pull request to it's own subdomain http://pr-[prnumber].manual.joomlacode.org

The reason for the joomlacode.org domain is that we can only have http with tls because of the restrictions by "free" certificate providers like letsencypt and cloudflare. We will see if we need to overcome this limitation.