### PR TITLE
external links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -150,11 +150,11 @@ const config = {
             items: [
               {
                 label: 'Blog',
-                to: 'https://community.joomla.org/blogs.html',
+                href: 'https://community.joomla.org/blogs.html',
               },
               {
                 label: 'Magazine',
-                to: 'https://magazine.joomla.org/',
+                href: 'https://magazine.joomla.org/',
               },
             ],
           },
@@ -163,11 +163,11 @@ const config = {
             items: [
               {
                 label: 'Privacy',
-                to: 'https://www.joomla.org/privacy-policy.html',
+                href: 'https://www.joomla.org/privacy-policy.html',
               },
               {
                 label: 'Terms',
-                to: 'https://tm.joomla.org',
+                href: 'https://tm.joomla.org',
               },
             ],
           },


### PR DESCRIPTION
docusauris uses _to_ for internal links and _href_ for external links

This way the link gets the icon to indicate that the link opens in a new tab etc.

In the footer the two community links were done this way but the More and Legal Links were not.

This PR corrects that

### after
![image](https://user-images.githubusercontent.com/1296369/184828107-20b01030-b677-4cf1-b35e-07f273bef12a.png)
