### PR TITLE
Footer hover accessibility

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -14,6 +14,7 @@
   --ifm-color-primary-lighter: #1f72ba;
   --ifm-color-primary-lightest: #2179c6;
   --ifm-code-font-size: 95%;
+  --ifm-footer-link-hover-color: var(--ifm-color-secondary);
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 
@@ -27,6 +28,7 @@
   --ifm-color-primary-lighter: #7eacd4;
   --ifm-color-primary-lightest: #9cbfde;
   --ifm-code-font-size: 95%;
+  --ifm-footer-link-hover-color: var(--ifm-color-secondary);
   --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 


### PR DESCRIPTION
The color of the links on hover in the footer fail basic contrast checks for accessibility.

As a quick fix this PR changes the value from primary to secondary using the recommended infima variables.

Test in both light and dark modes

### before
![image](https://user-images.githubusercontent.com/1296369/184831420-b6c241b8-2f8e-400e-82c5-f47e7195eb05.png)


### after
![image](https://user-images.githubusercontent.com/1296369/184831308-f1e86850-90f2-4e65-b3d7-76cfce3718d8.png)
