### PR TITLE
Adds documentation why we switched to getCurrentUser in template files and form fields

### DIFF
--- a/migrations/44-50/index.md
+++ b/migrations/44-50/index.md
@@ -14,7 +14,9 @@ Most of the code deprecated in Joomla! 3.x has been removed. Some deprecations h
 to the [Compatibility Plugin](compat-plugin.md).
 
 # Replacement of Factory::getUser
-`Factory::getUser()` is deprecated since Joomla 4.0. To replace it, models, views and tables can implement the `CurrentUserInterface` and then is the currently logged in user available through `$this->getCurrentUser()`. In 5.0 are all the template files (default.php) changed from `Factory::getUser()` to `$this->getCurrentUser()`.
+`Factory::getUser()` is deprecated since Joomla 4.0. To replace it, models, views, form fields and tables can implement the `CurrentUserInterface` and then is the currently logged in user available through `$this->getCurrentUser()`.
+
+In 5.0 are all the template files (default.php) changed from `Factory::getUser()` to `$this->getCurrentUser()`.
 
 
 :::caution TODO

--- a/migrations/44-50/index.md
+++ b/migrations/44-50/index.md
@@ -8,10 +8,13 @@ An explanation of the code changes for each version of Joomla.
 If you follow from the version of your current code until the version you want
 to support you should come across all the changes you need to make.
 
-# Combatibility Plugin
+# Compatibility Plugin
 
 Most of the code deprecated in Joomla! 3.x has been removed. Some deprecations have been moved
 to the [Compatibility Plugin](compat-plugin.md).
+
+# Replacement of Factory::getUser
+`Factory::getUser()` is deprecated since Joomla 4.0. To replace it, models, views and tables can implement the `CurrentUserInterface` and then is the currently logged in user available through `$this->getCurrentUser()`. In 5.0 are all the template files (default.php) changed from `Factory::getUser()` to `$this->getCurrentUser()`.
 
 
 :::caution TODO


### PR DESCRIPTION
Not sure yet where tho put this doc as it is just a change and no deprecation, feature or removal.