### PR TITLE
Add incompatibility of form field classes

### DIFF
--- a/migrations/44-50/index.md
+++ b/migrations/44-50/index.md
@@ -11,3 +11,14 @@ If you follow from the version of your current code until the version you want t
 This page is unfinished, please use the **Edit this Page** link at the bottom of this page to help make it more useful.
 
 :::
+
+## Form field classes
+There is a long list of old style form field classes that have no equivalent in Joomla 5. For example:
+- JFormFieldList
+- JFormFieldText
+
+In Joomla 5 the namespaced classes are:
+- \Joomla\CMS\Form\Field\ListField
+- \Joomla\CMS\Form\Field\TextField
+
+The namespaced version is not available in Joomla 3. If you want to run your extension on both Joomla 3 and Joomla 5 without the compatibility plugin you will have to refactor the use of these form field classes to use your own.


### PR DESCRIPTION
Describe the incompatibility of form field classes between Joomla 3 and Joomla 5 with compatibility plugin disabled.