### PR TITLE
Fix list of required PHP extensions for J5.x and J4.x

### DIFF
--- a/docs/get-started/technical-requirements.md
+++ b/docs/get-started/technical-requirements.md
@@ -25,7 +25,7 @@ All recommended versions are based on the latest released version of each series
 
 | Software           | Recommended[^4] | Minimum[^3] | More Information                                                                                                 |
 |--------------------|-----------------|-------------|------------------------------------------------------------------------------------------------------------------|
-| PHP                | 8.2             | 7.2.5       | https://www.php.net                                                                                              |
+| PHP                | 8.2             | 7.2.5       | https://www.php.net <br/>Modules: json, simplexml, dom, gd, mysqlnd or pdo_mysql or pdo_pgsql                    |
 | **Databases**      |                 |             |                                                                                                                  |
 | MySQL              | 8.0             | 5.6         | https://www.mysql.com                                                                                            |
 | PostgreSQL         | 11.0            | 11.0        | https://www.postgresql.org/ <br/>(ext/pgsql support in PHP has been removed. Now uses the PostgreSQL PDO Driver) |

--- a/docs/get-started/technical-requirements.md
+++ b/docs/get-started/technical-requirements.md
@@ -9,17 +9,17 @@ All recommended versions are based on the latest released version of each series
 ## Requirements for Supported Software
 ### Requirements for Joomla! 5.x
 
-| Software                                  | Recommended[^4] | Minimum[^3] | More Information                                    |
-|-------------------------------------------|-----------------|-------------|-----------------------------------------------------|
-| [PHP](https://php.net)                    | 8.2             | 8.1.0       | Modules: json, simplexml, dom, gd, mysqlnd or pgsql |
-| **Databases**                             |                 |             |                                                     |
-| [MySQL](https://mysql.com)                | 8.1             | 8.0.13      |                                                     |
-| [MariaDB](https://mariadb.com)            | 11.1.0          | 10.4.0      |                                                     |
-| [PostgreSQL](https://postgresql.org)      | 16.0            | 12.0        |                                                     |
-| **Web Servers**                           |                 |             |                                                     |
-| [Apache](https://httpd.apache.org) [^2]   | 2.4             | 2.4         |                                                     |
-| [Nginx](https://nginx.com)                | 1.25            | 1.21        |                                                     |
-| [Microsoft IIS](https://www.iis.net) [^1] | 10              | 10          |                                                     |
+| Software                                  | Recommended[^4] | Minimum[^3] | More Information                                                     |
+|-------------------------------------------|-----------------|-------------|----------------------------------------------------------------------|
+| [PHP](https://php.net)                    | 8.2             | 8.1.0       | Modules: json, simplexml, dom, gd, mysqlnd or pdo_mysql or pdo_pgsql |
+| **Databases**                             |                 |             |                                                                      |
+| [MySQL](https://mysql.com)                | 8.1             | 8.0.13      |                                                                      |
+| [MariaDB](https://mariadb.com)            | 11.1.0          | 10.4.0      |                                                                      |
+| [PostgreSQL](https://postgresql.org)      | 16.0            | 12.0        |                                                                      |
+| **Web Servers**                           |                 |             |                                                                      |
+| [Apache](https://httpd.apache.org) [^2]   | 2.4             | 2.4         |                                                                      |
+| [Nginx](https://nginx.com)                | 1.25            | 1.21        |                                                                      |
+| [Microsoft IIS](https://www.iis.net) [^1] | 10              | 10          |                                                                      |
 
 ### Requirements for Joomla! 4.x
 

--- a/docs/get-started/technical-requirements.md
+++ b/docs/get-started/technical-requirements.md
@@ -9,17 +9,17 @@ All recommended versions are based on the latest released version of each series
 ## Requirements for Supported Software
 ### Requirements for Joomla! 5.x
 
-| Software                                  | Recommended[^4] | Minimum[^3] | More Information                                                     |
-|-------------------------------------------|-----------------|-------------|----------------------------------------------------------------------|
-| [PHP](https://php.net)                    | 8.2             | 8.1.0       | Modules: json, simplexml, dom, gd, mysqlnd or pdo_mysql or pdo_pgsql |
-| **Databases**                             |                 |             |                                                                      |
-| [MySQL](https://mysql.com)                | 8.1             | 8.0.13      |                                                                      |
-| [MariaDB](https://mariadb.com)            | 11.1.0          | 10.4.0      |                                                                      |
-| [PostgreSQL](https://postgresql.org)      | 16.0            | 12.0        |                                                                      |
-| **Web Servers**                           |                 |             |                                                                      |
-| [Apache](https://httpd.apache.org) [^2]   | 2.4             | 2.4         |                                                                      |
-| [Nginx](https://nginx.com)                | 1.25            | 1.21        |                                                                      |
-| [Microsoft IIS](https://www.iis.net) [^1] | 10              | 10          |                                                                      |
+| Software                                  | Recommended[^4] | Minimum[^3] | More Information                                                           |
+|-------------------------------------------|-----------------|-------------|----------------------------------------------------------------------------|
+| [PHP](https://php.net)                    | 8.2             | 8.1.0       | Modules: json, simplexml, dom, zlib, gd, mysqlnd or pdo_mysql or pdo_pgsql |
+| **Databases**                             |                 |             |                                                                            |
+| [MySQL](https://mysql.com)                | 8.1             | 8.0.13      |                                                                            |
+| [MariaDB](https://mariadb.com)            | 11.1.0          | 10.4.0      |                                                                            |
+| [PostgreSQL](https://postgresql.org)      | 16.0            | 12.0        |                                                                            |
+| **Web Servers**                           |                 |             |                                                                            |
+| [Apache](https://httpd.apache.org) [^2]   | 2.4             | 2.4         |                                                                            |
+| [Nginx](https://nginx.com)                | 1.25            | 1.21        |                                                                            |
+| [Microsoft IIS](https://www.iis.net) [^1] | 10              | 10          |                                                                            |
 
 ### Requirements for Joomla! 4.x
 

--- a/versioned_docs/version-4.4/get-started/technical-requirements.md
+++ b/versioned_docs/version-4.4/get-started/technical-requirements.md
@@ -11,7 +11,7 @@ All recommended versions are based on the latest released version of each series
 
 | Software              | Recommended | Minimum[^Min] | More Information                                                                                                 |
 |-----------------------|-------------|---------------|------------------------------------------------------------------------------------------------------------------|
-| PHP                   | 8.2         | 7.2.5         | https://www.php.net                                                                                              |
+| PHP                   | 8.2         | 7.2.5         | https://www.php.net <br/>Modules: json, simplexml, dom, gd, mysqlnd or pdo_mysql or pdo_pgsql                    |
 | Supported Databases   |             |               |                                                                                                                  |
 | MySQL                 | 8.0 +       | 5.6           | https://www.mysql.com                                                                                            |
 | PostgreSQL            | 11.0 +      | 11.0          | https://www.postgresql.org/ <br/>(ext/pgsql support in PHP has been removed. Now uses the PostgreSQL PDO Driver) |

--- a/versioned_docs/version-4.4/get-started/technical-requirements.md
+++ b/versioned_docs/version-4.4/get-started/technical-requirements.md
@@ -11,7 +11,7 @@ All recommended versions are based on the latest released version of each series
 
 | Software              | Recommended | Minimum[^Min] | More Information                                                                                                 |
 |-----------------------|-------------|---------------|------------------------------------------------------------------------------------------------------------------|
-| PHP                   | 8.2         | 7.2.5         | https://www.php.net <br/>Modules: json, simplexml, dom, gd, mysqlnd or pdo_mysql or pdo_pgsql                    |
+| PHP                   | 8.2         | 7.2.5         | https://www.php.net <br/>Modules: json, simplexml, dom, zlib, gd, mysqlnd or pdo_mysql or pdo_pgsql              |
 | Supported Databases   |             |               |                                                                                                                  |
 | MySQL                 | 8.0 +       | 5.6           | https://www.mysql.com                                                                                            |
 | PostgreSQL            | 11.0 +      | 11.0          | https://www.postgresql.org/ <br/>(ext/pgsql support in PHP has been removed. Now uses the PostgreSQL PDO Driver) |

--- a/versioned_docs/version-5.0/get-started/technical-requirements.md
+++ b/versioned_docs/version-5.0/get-started/technical-requirements.md
@@ -25,7 +25,7 @@ All recommended versions are based on the latest released version of each series
 
 | Software           | Recommended[^4] | Minimum[^3] | More Information                                                                                                 |
 |--------------------|-----------------|-------------|------------------------------------------------------------------------------------------------------------------|
-| PHP                | 8.2             | 7.2.5       | https://www.php.net                                                                                              |
+| PHP                | 8.2             | 7.2.5       | https://www.php.net <br/>Modules: json, simplexml, dom, gd, mysqlnd or pdo_mysql or pdo_pgsql                    |
 | **Databases**      |                 |             |                                                                                                                  |
 | MySQL              | 8.0             | 5.6         | https://www.mysql.com                                                                                            |
 | PostgreSQL         | 11.0            | 11.0        | https://www.postgresql.org/ <br/>(ext/pgsql support in PHP has been removed. Now uses the PostgreSQL PDO Driver) |

--- a/versioned_docs/version-5.0/get-started/technical-requirements.md
+++ b/versioned_docs/version-5.0/get-started/technical-requirements.md
@@ -9,23 +9,23 @@ All recommended versions are based on the latest released version of each series
 ## Requirements for Supported Software
 ### Requirements for Joomla! 5.x
 
-| Software                                  | Recommended[^4] | Minimum[^3] | More Information                                                     |
-|-------------------------------------------|-----------------|-------------|----------------------------------------------------------------------|
-| [PHP](https://php.net)                    | 8.2             | 8.1.0       | Modules: json, simplexml, dom, gd, mysqlnd or pdo_mysql or pdo_pgsql |
-| **Databases**                             |                 |             |                                                                      |
-| [MySQL](https://mysql.com)                | 8.1             | 8.0.13      |                                                                      |
-| [MariaDB](https://mariadb.com)            | 11.1.0          | 10.4.0      |                                                                      |
-| [PostgreSQL](https://postgresql.org)      | 16.0            | 12.0        |                                                                      |
-| **Web Servers**                           |                 |             |                                                                      |
-| [Apache](https://httpd.apache.org) [^2]   | 2.4             | 2.4         |                                                                      |
-| [Nginx](https://nginx.com)                | 1.25            | 1.21        |                                                                      |
-| [Microsoft IIS](https://www.iis.net) [^1] | 10              | 10          |                                                                      |
+| Software                                  | Recommended[^4] | Minimum[^3] | More Information                                                           |
+|-------------------------------------------|-----------------|-------------|----------------------------------------------------------------------------|
+| [PHP](https://php.net)                    | 8.2             | 8.1.0       | Modules: json, simplexml, dom, zlib, gd, mysqlnd or pdo_mysql or pdo_pgsql |
+| **Databases**                             |                 |             |                                                                            |
+| [MySQL](https://mysql.com)                | 8.1             | 8.0.13      |                                                                            |
+| [MariaDB](https://mariadb.com)            | 11.1.0          | 10.4.0      |                                                                            |
+| [PostgreSQL](https://postgresql.org)      | 16.0            | 12.0        |                                                                            |
+| **Web Servers**                           |                 |             |                                                                            |
+| [Apache](https://httpd.apache.org) [^2]   | 2.4             | 2.4         |                                                                            |
+| [Nginx](https://nginx.com)                | 1.25            | 1.21        |                                                                            |
+| [Microsoft IIS](https://www.iis.net) [^1] | 10              | 10          |                                                                            |
 
 ### Requirements for Joomla! 4.x
 
 | Software           | Recommended[^4] | Minimum[^3] | More Information                                                                                                 |
 |--------------------|-----------------|-------------|------------------------------------------------------------------------------------------------------------------|
-| PHP                | 8.2             | 7.2.5       | https://www.php.net <br/>Modules: json, simplexml, dom, gd, mysqlnd or pdo_mysql or pdo_pgsql                    |
+| PHP                | 8.2             | 7.2.5       | https://www.php.net <br/>Modules: json, simplexml, dom, zlib, gd, mysqlnd or pdo_mysql or pdo_pgsql              |
 | **Databases**      |                 |             |                                                                                                                  |
 | MySQL              | 8.0             | 5.6         | https://www.mysql.com                                                                                            |
 | PostgreSQL         | 11.0            | 11.0        | https://www.postgresql.org/ <br/>(ext/pgsql support in PHP has been removed. Now uses the PostgreSQL PDO Driver) |

--- a/versioned_docs/version-5.0/get-started/technical-requirements.md
+++ b/versioned_docs/version-5.0/get-started/technical-requirements.md
@@ -9,17 +9,17 @@ All recommended versions are based on the latest released version of each series
 ## Requirements for Supported Software
 ### Requirements for Joomla! 5.x
 
-| Software                                  | Recommended[^4] | Minimum[^3] | More Information                                    |
-|-------------------------------------------|-----------------|-------------|-----------------------------------------------------|
-| [PHP](https://php.net)                    | 8.2             | 8.1.0       | Modules: json, simplexml, dom, gd, mysqlnd or pgsql |
-| **Databases**                             |                 |             |                                                     |
-| [MySQL](https://mysql.com)                | 8.1             | 8.0.13      |                                                     |
-| [MariaDB](https://mariadb.com)            | 11.1.0          | 10.4.0      |                                                     |
-| [PostgreSQL](https://postgresql.org)      | 16.0            | 12.0        |                                                     |
-| **Web Servers**                           |                 |             |                                                     |
-| [Apache](https://httpd.apache.org) [^2]   | 2.4             | 2.4         |                                                     |
-| [Nginx](https://nginx.com)                | 1.25            | 1.21        |                                                     |
-| [Microsoft IIS](https://www.iis.net) [^1] | 10              | 10          |                                                     |
+| Software                                  | Recommended[^4] | Minimum[^3] | More Information                                                     |
+|-------------------------------------------|-----------------|-------------|----------------------------------------------------------------------|
+| [PHP](https://php.net)                    | 8.2             | 8.1.0       | Modules: json, simplexml, dom, gd, mysqlnd or pdo_mysql or pdo_pgsql |
+| **Databases**                             |                 |             |                                                                      |
+| [MySQL](https://mysql.com)                | 8.1             | 8.0.13      |                                                                      |
+| [MariaDB](https://mariadb.com)            | 11.1.0          | 10.4.0      |                                                                      |
+| [PostgreSQL](https://postgresql.org)      | 16.0            | 12.0        |                                                                      |
+| **Web Servers**                           |                 |             |                                                                      |
+| [Apache](https://httpd.apache.org) [^2]   | 2.4             | 2.4         |                                                                      |
+| [Nginx](https://nginx.com)                | 1.25            | 1.21        |                                                                      |
+| [Microsoft IIS](https://www.iis.net) [^1] | 10              | 10          |                                                                      |
 
 ### Requirements for Joomla! 4.x
 


### PR DESCRIPTION
* implement the last suggestion on DB drivers from https://github.com/joomla/Manual/issues/230#issuecomment-1980448122
* Adds the same list to joomla 4
* also list `zlib` which is required for com_installer and com_joomlaupdate to have at least minimal functionality.
   zlib had already been listed as a requirement in J3.x