### PR TITLE
Fix a11y and seo Headlines

### DIFF
--- a/docs/building-extensions/components/mvc/library-mvc.md
+++ b/docs/building-extensions/components/mvc/library-mvc.md
@@ -2,10 +2,12 @@
 title: Library MVC Classes
 sidebar_position: 4
 ---
-# Joomla Library MVC Classes
+Joomla Library MVC Classes
+==========================
+
 Joomla provides several Controller, View and Model library classes, and this section gives an overview of these, and explains when your own component should use each class. However, it doesn't attempt to provide a full description of each class's functionality. The classes can be found in libraries/src/MVC.
 
-# Base MVC Classes
+## Base MVC Classes
 In practical terms, the lowest level classes you would be likely to use are:
 - BaseController in libraries/src/MVC/Controller/BaseController.php
 - HtmlView in libraries/src/MVC/View/HtmlView.php (for displaying web pages)
@@ -15,27 +17,27 @@ In practical terms, the lowest level classes you would be likely to use are:
 
 In general, using these base classes is a good option if your component is displaying a single item on a site page. 
 
-## BaseController
+### BaseController
 The functionality within BaseController includes: 
 - the `execute()` method described above, which runs the appropriate Controller function, based on the *task* parameter's `<method>` part (which is passed to it).
 - functions for determining the appropriate View and Model classes to use (based on the setting of the view parameter within the HTTP request), and getting the MVCFactory class to create them
 - a default `display()` method, which gets instances of the View and Model classes (including providing the View instance with a link to the Model instance), and then calls the `display()` method of the View class.
 
-## HtmlView
+### HtmlView
 The functionality within HtmlView includes: 
 - a default `display()` method, which runs the tmpl file
 - code for finding the tmpl file, taking into account a layout override which may have been put into the template folder structure
 - code for setting the model instance, and subsequently retrieving it
 
-## BaseDatabaseModel
+### BaseDatabaseModel
 The functionality within BaseDatabaseModel includes: 
 - code for getting an instance of the Table class (via the MVCFactory class)
 - base code for creating a model "state". This feature is useful if the component and/or several modules shown on the web page all use the same base data. In this case they may share the same Model instance and the model "state" acts like a container for sharing the values of items across the component and modules.
 
-# Higher-level Controller Classes
+## Higher-level Controller Classes
 There are 2 higher-level controller classes, each of which inherit from BaseController. 
 
-## AdminController 
+### AdminController 
 AdminController contains methods which handle the types of operations that can be performed on multiple items, for example:
 
 - delete
@@ -49,7 +51,7 @@ The name AdminController suggests that this controller is to be used only on the
 
 Note however that it doesn't support the operations enabled by the Batch button on e.g. the Content/Articles page; these POST requests are handled by the FormController.
 
-## FormController
+### FormController
 FormController contains methods which are associated with editing an individual item 
 
 - handling a request to edit an item – which involves checking that the user is allowed to edit the item and that it isn't already checked out, and if these checks pass then the item is checked out (if that component has enabled checkout) and a redirect is issued to display the edit form
@@ -60,14 +62,14 @@ FormController contains methods which are associated with editing an individual 
 
 The FormController is thus well suited to Actions 3 and 5 shown in the diagrams above in the [Post/Request/Get pattern](post-redirect-get.md) section.
 
-# Higher-level View Classes
+## Higher-level View Classes
 Apart from the CategoryFeedView, which is used for generating a [feed](https://docs.joomla.org/J3.x:Developing_an_MVC_Component/Adding_a_Feed), there are two higher level View classes in common usage:
 - CategoryView – for displaying a category and its children
 - CategoriesView – for displaying all the categories at a certain level in the category hierarchy, and the number of items associated with each category
 
 The two classes ListView and FormView seem to be aimed at functionality for displaying a list of records (like the `com_content` administrator View\Articles\HtmlView) and a form for editing a record (like the `com_content` administrator View\Article\HtmlView). However, at time of writing (Joomla 5 alpha has recently appeared), they aren't used by any of the Joomla components, so I wouldn't recommend using them, at least not yet.
 
-## Higher-level Model Classes
+### Higher-level Model Classes
 The diagram shows the inheritance tree of the Joomla library MVC models. 
 ![Model Class Hierarchy](_assets/model-hierarchy.jpg "Model Class Hierarchy")
 
@@ -87,32 +89,32 @@ Something to be aware of if you are using the same model across the "edit item" 
 
 When you're using the model because you're handling a POST (i.e. cases 3 and 5 in the diagram) then any effort expended in preparing the data for a web page is going to be wasted. (In fact, in the FormController `getModel()` method call, the parameter `$config` is set to `array('ignore_request' => true)` by default, which results in the model's `populateState` method not being run, to save this wasted effort.) 
 
-# Summary
+## Summary
 As we've seen, Joomla has rich functionality in higher level Controller and Model classes which can greatly simplify your code (all of which can be used on both the front end and back end). 
 
 The choice of which controller and model classes to extend is easier on the back end, because you just follow the pattern of the Joomla core components.
 
 For the front end here's a rough guide to choosing the most appropriate Controller and Model classes to extend; in each case you're using the standard HtmlView as base View class to extend.
 
-## Simple Display
+### Simple Display
 Simply displaying a record or a set of records, without providing the ability to change anything
 - Controller extends BaseController
 - Model extends BaseDatabaseModel or (particularly if you're sharing a model between a component and modules) ItemModel if it's a single record, ListModel if it's multiple records.
 
-## Displaying records, plus operations on selected records
+### Displaying records, plus operations on selected records
 Displaying a form with multiple records (but the form isn't defined in an XML file), including the providing the ability to select several records and apply some sort of operation to them (eg delete, publish):
 - Controller extends BaseController
 - Model extends ListModel – except if you're using the same model for displaying the form and handling the updates, in which case use AdminModel
 
-## Handling the HTTP POSTs from the above
+### Handling the HTTP POSTs from the above
 - Controller extends AdminController
 - Model extends AdminModel
 
-## Editing a record
+### Editing a record
 Displaying a form with a single record, where the form is defined in an XML file, and allowing the user to edit it, or a blank record and allowing the user to create a record:
 - Controller extends BaseController
 - Model extends FormModel – except if you're using the same model for displaying the form and handling the updates (as is usually the case), in which case use AdminModel
 
-## Handling the HTTP POSTs from the above
+### Handling the HTTP POSTs from the above
 - Controller extends FormController
 - Model extends AdminModel

--- a/docs/building-extensions/components/mvc/mvc-factory.md
+++ b/docs/building-extensions/components/mvc/mvc-factory.md
@@ -2,7 +2,10 @@
 title: The MVC Factory Class
 sidebar_position: 2
 ---
-# MVC Factory Overview
+
+MVC Factory Overview
+====================
+
 The MVC Factory class is used within Joomla to create instances of component Controller, View, Model and Table classes. 
 
 Each component has its own MVCFactory class instance, which is instantiated passing in that component's [namespace prefix](../../../general-concepts/namespaces/defining-your-namespace.md). 
@@ -27,10 +30,10 @@ $model = $this->getModel('example', 'administrator');
 ```
 Note that if your component is running in the front end (site) you can still use the administrator model, and if it's running in the back end (administrator) you can still use the site model. There is no restriction. 
 
-# Creating the MVCFactory class instance
+## Creating the MVCFactory class instance
 Your component's MVCFactory is created by defining it as a dependendency in your services/provider.php file, as described in [Dependency Injection](../../../general-concepts/dependency-injection/index.md), but you don't have to understand all the intricacies of Joomla Dependency Injection to use it effectively.
 
-# Creating your Controller class instance
+## Creating your Controller class instance
 
 As described in [Extension and Dispatcher Classes](../../../general-concepts/extension-and-dispatcher/index.md), your Controller class is instantiated within the `dispatch` function of the ComponentDispatcher class. It has an instance variable pointing to the MVCFactory class and will call:
 ```php
@@ -46,7 +49,7 @@ In this diagram (and in the next):
 - the solid black lines represent method calls
 - the thick solid red lines represent where a Factory class instantiates a class
 
-# Creating your View, Model and Table class instances
+## Creating your View, Model and Table class instances
 
 ![Instantiating View, Model, Table](_assets/mvc-factory.jpg "Instantiating View, Model, Table")
 
@@ -59,7 +62,7 @@ The View can also get the Model via a `getModel` call, but only if the Controlle
 $view->setModel($model);
 ```
 
-# Default names for View, Model and Table classes
+## Default names for View, Model and Table classes
 While the name for the Controller is taken from the *task* parameter, the default names for the View, Model and Table classes are taken from the *view* parameter. These default classes are what will be instantiated if you just call `getView()`, `getModel()` and `getTable()` without any parameters. 
 
 So, for example, the names of the classes created for a request with URL query "?option=com_example&view=viewname" and no *task* parameter will be:
@@ -68,7 +71,7 @@ So, for example, the names of the classes created for a request with URL query "
 - `<namespace>\Model\ViewnameModel`
 - `<namespace>\Table\ViewnameTable`
 
-# Summary
+## Summary
 We've covered a fair bit of background in this section, to give you an understanding of why things work, but it's all to make it easy for you in your MVC classes.
 
 In your Controller, you can create the View and the Model, and give the View a reference to the Model:
@@ -100,7 +103,7 @@ $table = $this->getTable();           // if your Table class matches the view= p
 $table = $this->getTable('example');  // to get the ExampleTable class
 ```
 
-# Issues
+## Issues
 A key reason for the introduction of the MVCFactory class was to remove the use of the `static::getInstance()` calls to obtain an instance of one of the MVC classes. However, you may find one or two problems with the approach.
 
 For example, when saving a database record in the Table class (eg in `Joomla\CMS\Table\Content::store()`), Joomla obtains another instance of that Table class in order to verify that the alias which is about to be saved is unique. However, when the Table instance is created it isn't passed a pointer to the MVCFactory instance, so it can't create another instance using the MVCFactory's `createTable` function. In Joomla 4 the solution was to use the deprecated `getInstance()` function:

--- a/docs/building-extensions/components/mvc/mvc-overview.md
+++ b/docs/building-extensions/components/mvc/mvc-overview.md
@@ -2,14 +2,18 @@
 title: MVC Overview
 sidebar_position: 1
 ---
-# MVC Overview
+MVC Overview
+============
+
 The diagram below depicts the MVC pattern as it's used in Joomla. This applies to both the admin back end and the site front end.
 
 ![MVC Overview](_assets/mvc-overview.jpg "MVC Overview")
 
+## Basic Elements
+
 In this section we will cover the 4 types of classes shown in the diagram. In your component you're likely to have several Controller, View and Model classes, and (if your component uses its own table or tables in the database) one Table class for each database table your component has. 
 
-## Controller
+### Controller
 Your Controller code is run whenever there's an incoming HTTP request which is routed to your component. The controller is responsible for analysing the user's request, checking that the user is allowed to perform that action and determining how to satisfy the request. The latter could involve:
 
 - determining which Model (or Models) will be needed to satisfy the request, and creating an instance of that Model
@@ -17,7 +21,7 @@ Your Controller code is run whenever there's an incoming HTTP request which is r
 - determining which View should be used to present the web page to the user, and creating an instance of that View or
 - if instead the user should receive a redirect to another URL, then determining that redirect URL.
 
-## View
+### View
 The MVC View functionality is split into 2 files
 
 1. A View class file, which is usually just known as the View, and after this we'll just call it the View
@@ -35,19 +39,19 @@ This means that if the View holds the response data in, for example, `$this->ite
 
 Separating the View and tmpl like this enables another level of flexibility, as you can easily set up a layout override to output the View data using your own preferred HTML. 
 
-## Model
+### Model
 The Model encapsulates the data used by the component. In most cases this data will come from a database, either the Joomla database, or some external database, but it is also possible for the Model to obtain data from other sources, such as via a web services API running on another server. The Model is also responsible for updating the database where appropriate. The purpose of the Model is to isolate the Controller and View from the details of how data is obtained or amended.
 
 If the component is displaying a form which is defined in XML using the Joomla Form approach, the Model handles the setting-up and configuration of the `Form` instance, ready for the tmpl to output fields using `$form->renderField()` etc. 
 
-## Table
+### Table
 If your extension has one or more database tables, then you should have a Table class for each database table. Your Table class will inherit from the Joomla library Table class, which provides CRUD (Create / Read / Update / Delete) access to the underlying database table.
 
 The Table class provides access to individual records only, so it would be used by the Model if the requirement was a CRUD operation on an individual record, eg to create or update a record in the database.
 
 If instead it's required to access several records in the database table, then the Model would access the database directly, rather than using the Table class.
 
-# The HTTP Request *task* Parameter
+## The HTTP Request *task* Parameter
 Joomla uses the HTTP Request *task* parameter to determine which controller should be used. The *task* parameter can be sent in an HTTP GET or an HTTP POST - Joomla doesn't mind which - and it's just an ordinary HTTP parameter, nothing special. 
 
 The *task* parameter is of the form `<controllerType>.<method>`. The first part identifies the particular Controller class to use, and the second part identifies that class's instance method to call.
@@ -58,7 +62,7 @@ If the task parameter is not set at all then the `display()` method in the Displ
 
 We'll look at some examples later on.
 
-# Your MVC within Joomla
+## Your MVC within Joomla
 Of course, your component's MVC code runs within the context of Joomla's library code, really like the meat in a sandwich. When Joomla determines that it should run your component, then it obtains your component's Extension and Dispatcher classes, and it's the `dispatch()` function of the Joomla ComponentDispatcher class which actually analyses the *task* parameter to determine which of your Controller classes to instantiate, as described in [Extension and Dispatcher classes](../../../general-concepts/extension-and-dispatcher/index.md). Then `dispatch()` calls your component's `execute()` method, passing the `<method>` part of the *task* parameter. Assuming your component has Joomla\CMS\MVC\Controller\BaseController in its inheritance chain, then this will result (in the normal case) in your Controller's `method` function being called. 
 
 After the `execute()` method completes the `dispatch()` method will call the Controller's `redirect()` method - we'll see the significance of this later. 

--- a/docs/building-extensions/components/mvc/post-redirect-get.md
+++ b/docs/building-extensions/components/mvc/post-redirect-get.md
@@ -2,22 +2,25 @@
 title: Post-Request-Get Pattern
 sidebar_position: 3
 ---
-# Post-Request-Get Pattern
+
+Post-Request-Get Pattern
+========================
+
 Joomla follows the [Post/Redirect/Get pattern](https://en.wikipedia.org/wiki/Post/Redirect/Get), which means that when a user submits a form in an HTTP POST, then rather than Joomla responding to the POST with an HTML page, it redirects to another page which the browser will access with an HTTP GET. In this section we'll look at a couple of examples of this, and see how it aligns with the use of the *task* parameter, and later with the Joomla library MVC classes.
 
 Although Joomla uses the Post-Request-Get Pattern extensively, this doesn't mean that you have to use it everywhere in your own component. For example, if your component has a front-end form which is used to submit an order, then it may make perfect sense to provide the order confirmation text as the HTTP response to the HTTP POST of the order submission. 
 
-# Example 1 Publish Articles
+## Example 1 Publish Articles
 The diagram shows the steps associated within publishing articles on the Joomla back-end. You'll probably find it helpful to perform these operations on your own Joomla instance, and use your browser's devtools to examine the HTTP requests and responses. 
 
 ![Publishing Articles](_assets/post-request-get1.jpg "Publishing Articles")
 
-## Action 1
+### Action 1
 The administrator clicks on Content / Articles to display the list of articles. This is simply an HTTP GET request to the `com_content` administrator webpage with the `view` parameter set to `articles`. (If SEF URLs are being used, then it's the Joomla Router which will set up the `view` parameter, based on parsing the incoming URL). The *task* parameter is not set in this HTTP request, and so the `com_content` DisplayController is instantiated and the `display()` method called. Based on the `view` parameter, the default View class is Joomla\Component\Content\Administrator\View\\**Articles**\HtmlView, and the default Model is Joomla\Component\Content\Administrator\Model\\**Articles**Model.
 
 A key thing to note is that this view displays various buttons at the top of the form. When you select one or more articles, then these buttons become visible in the Actions button drop-down at the top of the page. It is these buttons which trigger an HTTP POST to the server, and embedded within the buttons is what the *task* parameter gets set to within that POST request.  
 
-## Action 2
+### Action 2
 The administrator selects a number of articles and then presses the Publish button. At this point it's worth switching on your browser's devtools, and examining the messages. You'll see that pressing Publish triggers:
 - an HTTP POST request to the server with
 - the *task* parameter set to "articles.publish"
@@ -85,28 +88,28 @@ to get the `<method>` part of the *task* parameter, in order to code the differe
 
 Secondly, did you notice how much of the code to handle the publish operation was actually within the `com_content` code? Very little! Practically all the code was within the Joomla library MVC classes. Making judicious choices in how you name your component's fields and how your component's MVC classes extend the Joomla library classes can make it easy for you to include functionality with very little coding effort. We'll look at the Joomla library MVC classes in more detail in the next section.
 
-## Action 1 again
+### Action 1 again
 The URL redirect at the end of Action 2 results in the display of the list of articles again. However, this time the user will see a message like "2 articles published" at the top of the form. 
 
 There may be 2 administrators logged on simultaneously, and both displaying the list of articles around the same time. How does Joomla know which administrator should be shown the "2 articles published" message? The answer is that it uses cookies. When the administrator's browsers sends the HTTP GET request to display the list of articles it sends in the request all the cookies which the server previously sent to it. One of these will be used by the Joomla Session functionality as an index to the Session data which is stored for that user. The `enqueueMessage` function described above stores a message within this session data, and when Joomla processes the next HTTP request it will see that there's a message stored there and will output it to the page.
 
 You can see what's stored in your session data by switching on Joomla Debug in the global configuration, and then clicking on the little Joomla symbol at the bottom left of each web page. However you won't see any enqueued messages because when Joomla outputs an enqueued message it removes it from the session, so that it isn't displayed again on the next HTTP request. 
 
-# Example 2 Edit Article
+## Example 2 Edit Article
 ![Editing Articles](_assets/post-request-get2.jpg "Editing Articles")
 
-## Action 1
+### Action 1
 This is the same as above, displaying the list of articles.
 
-## Action 3
+### Action 3
 The administrator clicks on an article to edit it. If you switch off Search Engine Friendly (SEF) URLs in your Global Configuration / Site parameters, then you'll see that the link behind each article title is something like `http://yourdomain.org/administrator/index.php?option=com_content&task=article.edit&id=1`. So the HTTP GET request sent to the server will have *task* set to "article.edit", and this will result in the `com_content` ArticleController being instantiated, and its `edit()` function being called.
 
 Similar to what we found previously, there's no `edit` function within ArticleController.php, so what is run is the `edit` function in the class it extends, namely Joomla\CMS\MVC\Controller\FormController in libraries/src/MVC/Controller/FormController.php. It basically checks that the user is allowed to perform this operation, and if so, checks the content record out (by setting the `checked_out` and `checked_out_time` columns in the article record in the database), and sets up a redirect to display the article edit form.
 
-## Action 4
+### Action 4
 The redirect results in an HTTP GET to a URL like http://yourdomain.org/administrator/index.php?option=com_content&view=article&layout=edit&id=1. The *task* parameter is not set so this will be handled by the `com_content` DisplayController, in the `display()` function. It will use the `com_content` Article View class in src/View/Article/HtmlView.php, and the tmpl file used will be tmpl/article/edit.php (from the `layout` parameter). This displays the form for editing a single article.
 
-## Action 5
+### Action 5
 When the administrator clicks on `Save & Close` then this will result in an HTTP POST to the server, with the article's field values, and *task* set to "article.save". This will be routed to the `com_content` ArticleController, and its `save()` function. Once again the `save` function is absent, so it drops back to using the `save` function in the class which ArticleController extends, namely Joomla\CMS\MVC\Controller\FormController in libraries/src/MVC/Controller/FormController.php. This function does the following (in its 'happy path'):
 - checks the user is allowed to perform the operation
 - validates the data (ie the submitted article fields) 
@@ -115,6 +118,6 @@ When the administrator clicks on `Save & Close` then this will result in an HTTP
 - enqueues a confirmation message that the save succeeded
 - sets up a redirect back to the form showing the list of articles
 
-## Action 1 again
+### Action 1 again
 As before, this displays the list of articles, plus the enqueued message.
 

--- a/docs/building-extensions/components/table-columns.md
+++ b/docs/building-extensions/components/table-columns.md
@@ -1,21 +1,19 @@
 Hide Table Columns
-=======================
+==================
 
-
-
-# User-defined Hide Table Columns
+## User-defined Hide Table Columns
 All the core components have a button that lets the user decide which columns of a table to display.
 
-## Adding Hide Table Columns to your component
+### Adding Hide Table Columns to your component
 Adding this functionality to your own component is very simple and is usually a simple case of adding the code below to the `tmpl` file for the table.
 
-### Check if you are you using WebAssetManager
+#### Check if you are you using WebAssetManager
 Look for this line of code in the php block at the top of your `tmpl` file.
 ```
 $wa = $this->document->getWebAssetManager();
 ```
 
-### Already using WebAssetManager
+#### Already using WebAssetManager
 Add the following line to your existing code.
 
 ```
@@ -31,7 +29,7 @@ $wa->useScript('table.columns')
     ->useScript('multiselect');
 ```
 
-### Not using WebAssetManager (yet)
+#### Not using WebAssetManager (yet)
 Add the following code anywhere in the php block at the top of your `tmpl` file.
 
 ```
@@ -40,7 +38,7 @@ $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns');
 ```
 
-### Notes
+#### Notes
 Your table will need to be a valid html table with a `<thead>` and each column a `<th>`.
 
 If you have multiple tables on the page and you want to prevent the script loading on one of those tables then you can add the class "columns-order-ignore" to the table.

--- a/docs/building-extensions/custom-script/basic-script.md
+++ b/docs/building-extensions/custom-script/basic-script.md
@@ -3,7 +3,8 @@ title: Example PHP Script
 sidebar_position: 2
 ---
 
-# Example PHP Script
+Example PHP Script
+==================
 
 :::danger[Developer Notice]
 

--- a/docs/building-extensions/custom-script/index.md
+++ b/docs/building-extensions/custom-script/index.md
@@ -2,7 +2,8 @@
 title: Custom PHP Script
 ---
 
-# Custom PHP Script
+Custom PHP Script
+=================
 
 :::danger[Developer Notice]
 

--- a/docs/building-extensions/custom-script/install.md
+++ b/docs/building-extensions/custom-script/install.md
@@ -3,7 +3,8 @@ title: Installing a custom script
 sidebar_position: 3
 ---
 
-# Install
+Install
+=======
 
 :::danger[Developer Notice]
 

--- a/docs/building-extensions/custom-script/logging-on.md
+++ b/docs/building-extensions/custom-script/logging-on.md
@@ -3,7 +3,8 @@ title: To Logon or not to Logon
 sidebar_position: 2
 ---
 
-# To Logon or not to Logon
+To Logon or not to Logon
+========================
 
 :::danger[Developer Notice]
 

--- a/docs/building-extensions/index.md
+++ b/docs/building-extensions/index.md
@@ -3,13 +3,14 @@ sidebar_position: 5
 ---
 Build Extensions
 ================
+
 Joomla is a rich featured content management system, but if you're building a website with Joomla and you need extra features which aren't available by default, then you can easily extend it with extensions. There are five common types of extensions for Joomla: Components, Modules, Plugins, Templates, and Languages. There are three others: Packages, Files and Libraries. Each of these extensions handle specific functionality (many built-in features of Joomla are implemented using extensions).
 
 The difference between Joomla components, modules, plugins and templates can be initially confusing. If you're new to Joomla then you may find it useful to watch the video [How Joomla Works - a guide for extension developers](https://youtu.be/JKnq47Yhtvs), which describes how these 4 types of extension fit into the generation of a Joomla web page. Their output is also highlighted in different colours in the diagram below. 
 
 ![Screenshot showing extension types](./_assets/screenshot-extension-types.jpg)
 
-# Components
+## Components
 [Components](./components/index.md) provide the central part of a web page on a Joomla site; each site web page displays the output from one component. They can be thought of as mini applications. Most components have two parts: a site part and an administrator part. For example, `com_content` is the component which handles articles; on the site front-end `com_content` displays articles to website visitors and on the back-end `com_content` provides the functionality for administrators to edit articles. 
 
 In general, components manage the data of the Joomla instance and provide functionality for creating, editing, removing and displaying the data. Often the data management aspects are handled in the administrator back-end and the site front-end simply displays the data, but this split of responsibility is not mandated, and some components provide front-end functionality for creating/editing/removing data.
@@ -21,7 +22,7 @@ When you navigate to a certain page on a site or perform a certain operation suc
 
 Examples of component functionality available from third party extensions include backup utilities and support for eCommerce. 
 
-# Modules
+## Modules
 [Modules](./modules/index.md) are more lightweight and flexible extensions displayed on a web page. Modules are mostly known as the “boxes” that are arranged around a component, for example: the login module or the breadcrumbs module. Modules are assigned per menu item. So you can decide to show or hide the login module depending on which menu item the user is viewing. 
 
 A module can often be a companion to the component. For example, if your web page displays an article (`com_content` component) then you might have a module (`mod_tags_similar`) in the sidebar which displays links to related articles, or a module which displays an image slider of related photos.
@@ -33,32 +34,32 @@ However, modules do not need to be linked to components, as a matter of fact the
 
 If you're just beginning with Joomla extension development then developing a module is the easiest place to start. 
 
-# Plugins
+## Plugins
 [Plugins](./plugins/index.md) work behind the scenes to modify or enhance the basic Joomla functionality. In the execution of any part of Joomla - be it the core, a module or a component - an event can be triggered. When an event is triggered, plugins which are registered to handle that event execute, and are passed data related to that event. The plugin can then, for example, modify the data and return it to the core Joomla code. For example, a plugin could be used to intercept user-submitted articles and filter out bad words.
 
 - Examples: Content pagenavigation plugin (which generates the Prev and Next links as shown in the screenshot above)
 - Management feature: Admin menu → System → Plugins
 
-# Templates
+## Templates
 A [template](./templates/index.md) is basically the design of your Joomla-powered website. With a template you define the look and feel of your website, primarily based on CSS. Templates have certain fields in which the component (just one) and modules (as many as you like) will be shown. Building a complete Joomla template from scratch is difficult because you have to understand the variety of HTML output by the Joomla components, and the CSS classes which are used within them. However, it is relatively easy to customize the Atum (administrator) and Cassiopeia (site) templates which are shipped with Joomla, particularly as you can use the Joomla child template functionality to simply specify deviations from the parent template. 
 
 - Management feature: Admin menu → System → Templates
 
-# Languages
+## Languages
 Probably the most basic extensions are languages. Languages can be packaged in two ways: either as a core package or as an extension package. In essence, both the core and the extension language package files consist of key/value pairs, which provide the translation of static text strings, assigned within the Joomla source code. These language packs will affect both the front and administrator side of your Joomla instance. Note: these language packs also include an XML meta file which describes the language.
 
 - Management feature: Admin menu → System → Manage / Languages
 
-# Libraries
+## Libraries
 Libraries are standalone PHP snippets that Joomla uses. Note nearly all of Joomla's core code is available as a library within the libraries/src folder. All composer libraries (such as PHPMailer) are installed as a library "vendor" within libraries/vendor. Many of the most popular 3rd party extensions in Joomla use libraries to reuse common functionality across their components. 
 
-# File
+## File
 The File extension type is used to install individual files into a directory of the Joomla instance. There are no examples in Joomla Core of this type and it is the least used type, however it can be used for example to place [custom scripts](./custom-script/index.md) into the Joomla cli directory or to place template overrides into a specific directory. 
 
-# Packages
+## Packages
 Packages are simply a group of any of the above types of extensions. A common use of a package would be to ship a template that also bundles a system plugin. Or a component that also installs a library it uses. In Joomla many language packs install as a package so that the frontend and backend languages can be installed independently. 
 
-# Extension Installation
+## Extension Installation
 There are 4 methods of installing an extension. You can install from the Joomla Extension Directory (Install from Web), upload the zip file of an extension, install from a folder or install from a URL. 
 
 ![Screenshot showing installing an extension](./_assets/screenshot-install-extension.jpg)

--- a/docs/building-extensions/install-update/install.md
+++ b/docs/building-extensions/install-update/install.md
@@ -12,7 +12,8 @@ This section is missing, please use the **Edit this Page** link at the bottom of
 There are various methods for installing an extension in Joomla!, but ultimately, the extension is always
 installed with the same functionality.
 
-# The Workflow explained
+The Workflow explained
+======================
 
 :::note TODO
 

--- a/docs/building-extensions/plugins/_assets/filesystem-plugin-ftp.md
+++ b/docs/building-extensions/plugins/_assets/filesystem-plugin-ftp.md
@@ -2,14 +2,18 @@
 title: Filesystem Plugin - FTP
 sidebar_position: 7
 ---
+
+FTP Filesystem Plugin
+=====================
+
 This plugin builds on the [basic filesystem plugin](filesystem-plugin-basic.md) to demonstrate how you can enable Joomla to use a media filesystem which is not within the local filestore. In this case we develop a plugin which enables the media filestore to be accessed via FTP.
 
-# Writing an FTP Filesystem Plugin
+## Writing an FTP Filesystem Plugin
 To write an FTP Filesystem plugin you need to provide 2 classes:
 1. The Provider class, which implements `Joomla\Component\Media\Administrator\Provider\ProviderInterface` in administrator/components/com_media/src/Provider/ProviderInterface.php. This is straightforward, and you just copy the approach of the Local Filesystem plugin in plugins/filesystem/local/src/Extension/Local.php. The main plugin (Extension) class doubles as the Provider class.
 2. The Adapter class, which implements `Joomla\Component\Media\Administrator\Adapter\AdapterInterface` in administrator/components/com_media/src/Adapter/AdapterInterface.php. This is where the bulk of the work lies, as you have to map the various types of file operations to ftp calls. The set of PHP ftp functions available to you is listed in [FTP Functions](https://www.php.net/manual/en/ref.ftp.php).
 
-## Testing
+### Testing
 To test the FTP aspects you need to install an FTP server on your local machine. I used [Filezilla](https://filezilla-project.org/) to test the filesystem plugin code below, but note that there can be interface differences between different FTP server implementations. In particular, the PHP function `ftp_mlsd` may not be available and you will need to use `ftp_nlist` or `ftp_rawlist` instead.
 On Filezilla I configured a test user, and a mount point which mapped `/shared` to a folder on my PC. As these details need to be known by the plugin, they're set as plugin config parameters defined in the XML manifest file:
 - host: I used localhost
@@ -18,7 +22,7 @@ On Filezilla I configured a test user, and a mount point which mapped `/shared` 
 - ftproot: virtual path of the mount point; I used "shared"
 
 I found it useful to write a small PHP program which enabled me to see the results of calling the various ftp functions.
-## FTP Connection
+### FTP Connection
 You have to open and close the FTP connection on each HTTP request, as the connection may time out if you try and leave it open between HTTP requests. In this filesystem plugin code the opening and user login is done in the constructor, and the closing in the destructor.
 
 ```php
@@ -41,7 +45,7 @@ public function __destruct()
 }
 
 ```
-## URLs
+### URLs
 If you're wanting to include your media on your front-end web site, then you will need to provide URLs to enable visitors to access them, and you do this via the `getUrl()` function of your adapter. You have 2 possibilities:
 - if you have a web server on the same server as your ftp server, and if the ftp directory is accessible from the web server, then you can just form the URL related to this web server.
 - otherwise you will have to copy the file down from the ftp server and store it in a local directory, and form the URL related to the local file.
@@ -73,9 +77,9 @@ public function getUrl(string $path): string
 ```
 
 To avoid repeatedly downloading the file the code checks if the file is already present in the /tmp directory. Of course, this won't work in a production environment as the file contents may be changed on the ftp server, but you could improve this approach to build some cacheing capability. 
-## File or Directory?
+### File or Directory?
 Much of the complexity in several functions (eg `getFile`, `getFiles`) arises because you have to determine whether it's a file or a directory which has been passed as a `$path`. The strategy in the code is to call `ftp_mlsd` on the parent directory and try to match the filename in the results returned. An alternative approach would be to try `ftp_chdir` on the `$path`and see if that works or not. 
-## Error handling
+### Error handling
 The filesystem plugin code reports errors using the Joomla logging mechanism, so you need to have that enabled via the Joomla global configuration.
 
 ```php
@@ -96,24 +100,24 @@ If you attempt to delete a directory which is not empty or rename a directory wh
 - ftp_rename(): Permission denied 
 
 Also, you may find a Joomla error reported "The account was not found". You can circumvent this by using your browser's dev tools to clear the session storage and local storage. (This was due to an early bug in the media manager, which was fixed, but still appears on rare occasions).
-## Not implemented
-### Thumbnails
+### Not implemented
+#### Thumbnails
 The code does not implement [thumbnails](https://en.wikipedia.org/wiki/Thumbnail). To implement this functionality you should fit your thumbnails into 200 x 200 pixels, and you will need to provide URLs for them as described above, and return the URL in the `thumb_path` field of the object returned in `getFile` and `getFiles`. (Note that the comments before these functions in the AdapterInterface.php file are not complete, and you should compare what's written in the code of the Joomla local adapter plugin).
-### Mime Types
+#### Mime Types
 The code includes a map from file extension to mime type, but only for a few extensions. You can find better lists online, eg [here](https://github.com/ralouphie/mimey). If the media type isn't an image then the media manager uses the mime type to determine the icon to display, so you need to set it to something which the media manager will recognise.
-### Uploading Files
+#### Uploading Files
 Obviously you need to be very careful when uploading files from the internet to avoid hackers uploading malware. You need to make the code below more robust, eg checking the filename more rigorously and using `MediaHelper::canUpload()`.
-### Search
+#### Search
 The `search()` function has not been implemented. Although you could form a GET request which would result in it being called, this doesn't seem to be initiated by media-manager.js (which implements its own search functionality). 
-### Joomla API
+#### Joomla API
 The functionality hasn't been tested using HTTP requests to the Joomla API. 
 
-# Plugin Source Code
+## Plugin Source Code
 You can copy the source code below into a directory `plg_filesystem_ftp`, or download the complete plugin from [download FTP filesystem plugin](./_assets/plg_filesystem_ftp.zip).
 
 Once installed, remember to enable the plugin! You also need to run your local FTP server, and configure the plugin with details of your FTP server.
 
-## Manifest File
+### Manifest File
 
 ```php title="plg_filesystem_ftp/ftp.xml"
 <?xml version="1.0" encoding="UTF-8"?>
@@ -173,7 +177,7 @@ Once installed, remember to enable the plugin! You also need to run your local F
 
 ```
 
-## Service Provider File
+### Service Provider File
 This is boilerplate code for instantiating the plugin via the Joomla Dependency Injection Container.
 
 ```php title="plg_filesystem_ftp/services/provider.php"
@@ -209,7 +213,7 @@ return new class () implements ServiceProviderInterface {
 };
 ```
 
-## Plugin / Provider class
+### Plugin / Provider class
 This has been adapted from the equivalent class in the Joomla Local filesystem plugin.
 
 ```php title="plg_filesystem_ftp/src/Extension/Ftp.php"
@@ -297,7 +301,7 @@ final class Ftp extends CMSPlugin implements ProviderInterface
 }
 ```
 
-## Adapter Class
+### Adapter Class
 This is where all the work happens! There's clearly overlap between the code in `getFile` and `getFiles`, but the code has been left like this to make it easier to appreciate what each function has to do.
 
 ```php title="plg_filesystem_ftp/src/Adapter/FtpAdapter.php"

--- a/docs/building-extensions/plugins/ajax-plugin.md
+++ b/docs/building-extensions/plugins/ajax-plugin.md
@@ -2,7 +2,11 @@
 title: Ajax Plugin for Ad Hoc Jobs
 sidebar_position: 4
 ---
-# Introduction
+
+Ajax Plugin
+===========
+
+## Introduction
 
 Imagine a Joomla site which handles bookings for events. On the day of the event the people putting out the chairs want to know how many people are coming, so they enter a URL on their browser which runs a job on the Joomla site and outputs the number of attendees.
 
@@ -25,7 +29,7 @@ language:9
 …
 ```
 
-# Writing an Ajax plugin
+## Writing an Ajax plugin
 To write a plugin which handles the URL
 
 ```
@@ -50,7 +54,7 @@ In the URL which you enter to run the functionality you have to specify as query
 
 You can obviously specify other query parameters which you can then capture using [Input](../../general-concepts/input.md) and use in the logic of your function.
 
-# Site, Administrator and Logged-on Users
+## Site, Administrator and Logged-on Users
 If you look at the Joomla code, then you'll see that site `com_ajax` and the administrator `com_ajax` are exactly the same. So you could run the code using:
 
 ```
@@ -64,7 +68,7 @@ Also if the user is running the job after having been logged into the Joomla sit
 
 If you decide to use hard-coded credentials to login a user within your code, then you should ensure that they're logged out before you exit (as described in [to logon or not to logon](https://manual.joomla.org/docs/building-extensions/custom-script/logging-on)), and wrap functions which you call in try / catch blocks so that you can catch any exceptions. Otherwise the logged-in state will persist through the session cookie. 
 
-# Ajax Plugin code
+## Ajax Plugin code
 This section contains the full source code for the ajax plugin. You can write the plugin manually by copying the code below, or you can download the zip file from [Download Ajax Plugin GetExtensionTotals](./_assets/plg_ajax_jobs.zip). If you're writing it manually then include the following files in a folder eg `plg_ajax_jobs`.
 
 Install the zip file and enable the plugin. Then enter the URL (replacing example.com with your domain):
@@ -76,7 +80,7 @@ This should then display the number of each different type of extension on your 
 
 Unfortunately it's not possible to create a nice SEF URL for `com_ajax` URLs. If you really want an easy-to-use URL then you would have to configure some rewrite rules in your web server. 
 
-## Manifest file
+### Manifest file
 A standard manifest file for a plugin:
 
 ```xml title="plg_ajax_jobs/jobs.xml"
@@ -95,7 +99,7 @@ A standard manifest file for a plugin:
 </extension>
 ```
 
-## Service Provider file
+### Service Provider file
 A standard service provider file for instantiating a plugin via the dependency injection container:
 
 ```php title="plg_ajax_jobs/services/provider.php"
@@ -131,7 +135,7 @@ use My\Plugin\Ajax\AjaxJobs\Extension\Jobs;
     };
 ```
 
-## Jobs file
+### Jobs file
 This is where you write your code for your ad hoc jobs. The result is returned as described in [Joomla 4 and 5 Changes](joomla-4-and-5-changes.md).
 
 ```php title="plg_ajax_jobs/src/Extension/Jobs.php"

--- a/docs/building-extensions/plugins/basic-console-plugin-helloworld.md
+++ b/docs/building-extensions/plugins/basic-console-plugin-helloworld.md
@@ -2,7 +2,12 @@
 title: Basic Console Plugin - Hello World
 sidebar_position: 4
 ---
-# Introduction
+
+Basic Console Plugin - Hello World
+==================================
+
+
+## Introduction
 Console applications were introduced in Joomla 4, and are now the Joomla strategic way of writing command line applications. You may also hear these called CLI applications. They are PHP applications which utilise the Joomla framework and are run from the command line where your Joomla instance is hosted, so you can run these applications:
 - from a terminal session on the server
 - from a cron job on the server
@@ -32,7 +37,7 @@ and the application will output "Hello World".
 
 You may find it useful to watch this video [Adding commands to the CLI Update](https://www.youtube.com/watch?v=gcJJtTcPiTg) but be aware that this video (for Joomla core developers) describes creating commands by changing a library file, whereas you must use a plugin instead. 
 
-# What you have to do
+## What you have to do
 You need to write 2 classes:
 - one class (ConsolePlugin below) handles the aspects associated with the Joomla plugin mechanism
 - one class (Command below) contains the code for the command
@@ -58,7 +63,7 @@ In this example the 2 classes are:
 - HelloworldConsolePlugin - which handles the plugin aspects, and, 
 - RunHelloCommand which writes out "Hello World", and contains information about the command..
 
-## Console plugin code
+### Console plugin code
 Following the sequence diagram above, the code for HelloworldConsolePlugin is:
 
 ```php
@@ -76,7 +81,7 @@ public function registerCommands(): void
 }
 ```
 
-## The Command configure() call
+### The Command configure() call
 
 ```php
 protected function configure(): void
@@ -118,7 +123,7 @@ This also is displayed whenever the user enters
 php cli/joomla.php
 ```
 
-## The Command doExecute() call
+### The Command doExecute() call
 Finally, `doExecute()` is called on `RunHelloCommand` to execute the command, and the code writes out "Hello World"
 
 ```php
@@ -134,12 +139,12 @@ To handling the I/O Joomla has incorporated the [Symfony Style](https://symfony.
 
 The function returns an exit code, which on successful completion should be the int zero. This code is what the Joomla php application will exit with, so you can capture this if you're running the command within a batch process.
 
-# Plugin Code
+## Plugin Code
 This section contains the full source code for the console plugin. You can write the plugin manually by copying the code below, or you can download the zip file from [Download Console Plugin Helloworld](./_assets/plg_helloworld_cli.zip). If you're writing it manually then include the following files in a folder eg `plg_helloworld_cli`.
 
 As described [here](basic-content-plugin.md), there are a number of things you need to ensure are consistent across your source code files when you're developing plugins. That example also includes how to use language files to make your plugin language-independent. For simplicity this helloworld example supports only English. 
 
-## Manifest file
+### Manifest file
 
 ```xml title="plg_helloworld_cli/helloworld.xml"
 <?xml version="1.0" encoding="utf-8"?>
@@ -157,7 +162,7 @@ As described [here](basic-content-plugin.md), there are a number of things you n
 </extension>
 ```
 
-## Service provider file
+### Service provider file
 The `services/provider.php` file is fairly standard boilerplate code; you just need to code correctly the 3 lines which relate to your plugin, plus the Application is injected as it's accessed within the console plugin code. 
 
 ```php title="plg_helloworld_cli/services/provider.php"
@@ -202,7 +207,7 @@ return new class implements ServiceProviderInterface
 };
 ```
 
-## Console Plugin file
+### Console Plugin file
 The file below handles the interaction with the Joomla plugin framework:
 
 ```php title="plg_helloworld_cli/src/Extension/HelloworldConsolePlugin.php"
@@ -233,7 +238,7 @@ class HelloworldConsolePlugin extends CMSPlugin implements SubscriberInterface
 }
 ```
 
-## Command file
+### Command file
 The file below handles the execution of the hello:world command.
 
 ```php title="plg_helloworld_cli/src/CliCommand/RunHelloworldCommand.php"
@@ -296,7 +301,7 @@ EOF
 }
 ```
 
-## Installation
+### Installation
 Generate a zip file from the folder and install the plugin in the usual way. Remember to enable the plugin!
 
 Then in a terminal session navigate to the top level of your Joomla instance and enter:

--- a/docs/building-extensions/plugins/basic-content-plugin.md
+++ b/docs/building-extensions/plugins/basic-content-plugin.md
@@ -2,6 +2,10 @@
 title: Basic Content Plugin
 sidebar_position: 3
 ---
+
+Basic Content Plugin
+====================
+
 # Introduction
 In this section we develop a plugin to provide a feature similar to the shortcodes feature in Wordpress. With this we can include in an article a reference to a field:
 ```

--- a/docs/building-extensions/plugins/console-plugin-sqlfile.md
+++ b/docs/building-extensions/plugins/console-plugin-sqlfile.md
@@ -2,9 +2,10 @@
 title: Console Plugin 2 SQLfile
 sidebar_position: 5
 ---
-# Console Plugin Example - Execute a file of SQL statements
+Console Plugin Example - Execute a file of SQL statements
+=========================================================
 
-# Introduction
+## Introduction
 This example expands the concepts described in the [Basic Helloworld Console Plugin](./basic-console-plugin-helloworld.md) to cover:
 - plugin options 
 - defining an argument in the command line
@@ -13,7 +14,7 @@ This example expands the concepts described in the [Basic Helloworld Console Plu
 
 It describes the use of several methods of the `Joomla\Console\Command\AbstractCommand` class.
 
-# Functionality
+## Functionality
 This console plugin enables a CLI utility called `sql:execute-file` to run a series of SQL commands in a file, where the commands include the Joomla table prefix, as in:
 
 ```sql title="sqlfile.sql"
@@ -37,12 +38,12 @@ Finally, we incorporate a plugin option which controls whether transaction contr
 
 For simplicity we'll just use the English language within the plugin; to see how to make your plugin multilingual look at [Basic Content Plugin](./basic-content-plugin.md). 
 
-# Overall Design
+## Overall Design
 As in the Basic Console Plugin there are 2 main classes:
 - a console plugin class which handles the aspects associated with the Joomla plugin mechanism
 - a command class which contains the code for the command
 
-# Console Plugin Class
+## Console Plugin Class
 Here's the core of our plugin class:
 
 ```php
@@ -71,7 +72,7 @@ Within `registerCommands()` we then do 3 things
 - inject into our command class the plugin params (we'll look at this in more detail shortly)
 - add our command class instance to the core Joomla console application.
 
-## Plugin Params
+### Plugin Params
 We define a configurable parameter for the plugin by including in the manifest file:
 
 ```xml
@@ -108,11 +109,11 @@ $transactionControl = $this->getParams()->get('txn', 1);
 
 The string 'txn' has to match the `name` attribute of our field in the `<config>` section in the manifest file. 
 
-# Command Class
+## Command Class
 The command class extends `Joomla\Console\Command\AbstractCommand` and the APIs associated with this class are listed in the [API docs](
 https://api.joomla.org/framework-3/classes/Joomla-Console-Command-AbstractCommand.html). We used a number of these APIs in the [Basic Helloworld Console Plugin](./basic-console-plugin-helloworld.md), and here we explore several more.
 
-## Defining an argument
+### Defining an argument
 You define in your command class's `configure()` method what arguments you want your command to have . To define an argument you use eg:
 
 ```php
@@ -137,7 +138,7 @@ protected function doExecute(InputInterface $input, OutputInterface $output): in
     ...
 ```
 
-## Defining an option
+### Defining an option
 You define the options also in the `configure()` method, eg
 
 ```php
@@ -168,7 +169,7 @@ $logfile = $logpath . '/' . ltrim($logging, "=");
 
 The code in the plugin sets `$logpath` to the Global Configuration Logging / "Path to Log Folder" parameter. 
 
-## Using a Joomla-defined option
+### Using a Joomla-defined option
 Joomla provides a 'help' option which enables you display help text
 
 ```
@@ -187,7 +188,7 @@ The standard help text also displays a number of other options which Joomla pred
 $verbose = $input->getOption('verbose');
 ```
 
-## getSynopsis()
+### getSynopsis()
 This function returns a string explaining the usage of the command, and you can obtain the short or the long version:
 
 ```php
@@ -203,12 +204,12 @@ php cli/joomla.cli sql:execute-file -h
 
 Note how it matches the "Usage:" section at the top of the help output.
 
-# Plugin Code
+## Plugin Code
 This section contains the full source code for the console plugin. You can write the plugin manually by copying the code below, or you can download the zip file from [Download Console Plugin Sqlfile](./_assets/plg_console_sqlfile.zip). If you're writing it manually then include the following files in a folder eg `plg_console_sqlfile`.
 
 As described [here](basic-content-plugin.md), there are a number of things you need to ensure are consistent across your source code files when you're developing plugins. That example also includes how to use language files to make your plugin language-independent. For simplicity this console plugin example supports only English. 
 
-## Manifest File
+### Manifest File
 
 ```xml title="plg_console_sqlfile/sqlfile_cli.xml"
 <?xml version="1.0" encoding="utf-8"?>
@@ -241,7 +242,7 @@ As described [here](basic-content-plugin.md), there are a number of things you n
 </extension>
 ```
 
-## Service provider file
+### Service provider file
 The `services/provider.php` file is fairly standard boilerplate code for instantiating the plugin via the Dependency Injection Container; you just need to code correctly the 3 lines which relate to your plugin, plus the Application is injected as it's accessed within the console plugin code. 
 
 ```php title="plg_console_sqlfile/services/provider.php"
@@ -286,7 +287,7 @@ return new class implements ServiceProviderInterface
 };
 ```
 
-## Console Plugin file
+### Console Plugin file
 The file below handles the interaction with the Joomla plugin framework:
 
 ```php title="plg_console_sqlfile/src/Extension/SqlfileConsolePlugin.php"
@@ -319,7 +320,7 @@ class SqlfileConsolePlugin extends CMSPlugin implements SubscriberInterface
 }
 ```
 
-## Command file
+### Command file
 The file below handles the execution of the `sql:execute-file` command.
 
 ```php title="plg_console_sqlfile/src/CliCommand/RunSqlfileCommand.php"
@@ -479,7 +480,7 @@ EOF
 }
 ```
 
-## Installation and Execution
+### Installation and Execution
 Generate a zip file from the folder and install the plugin in the usual way. Remember to enable the plugin!
 
 Then in a terminal session navigate to the top level of your Joomla instance and enter:

--- a/docs/building-extensions/plugins/filesystem-plugin-basic.md
+++ b/docs/building-extensions/plugins/filesystem-plugin-basic.md
@@ -2,7 +2,11 @@
 title: Filesystem Plugin - Basic
 sidebar_position: 6
 ---
-# Introduction
+
+Filesystem Plugin - Basic
+=========================
+
+## Introduction
 Prior to Joomla version 4, for images and other types of media which you wanted to display on your Joomla site you had to store the files within a subfolder of your Joomla instance, by default /images. 
 
 With the media manager introduced in Joomla 4 the development team abstracted the idea of a "filesystem" to be a "filesystem adapter" - ie a PHP class which offered file-like functionality such as file create, rename, delete, etc. This then opened up the possibility of storing the media files in a location other than the local filesystem, for example, on a server within the "cloud". 
@@ -13,7 +17,7 @@ This section demonstrates how to develop a basic filesystem plugin. It will be s
 
 In the next section the [FTP Filesystem plugin](filesystem-plugin-ftp.md) will demonstrate how you can store media files on an FTP server. 
 
-# Filesystem Providers and Adapters
+## Filesystem Providers and Adapters
 ![Media Manager Screenshot](./_assets/screenshot-filesystem-adapters.png "Media Manager Screenshot")
 
 The media manager screenshot shows a Joomla instance with 2 filesystem providers:
@@ -32,7 +36,7 @@ The Restricted provider has just 1 filesystem adapter called "restricted". This 
 
 The order of the providers shown is determined by the `ordering` of the filesystem plugins, set via the administrator System / Plugins page.
 
-# How Joomla Media Manager works
+## How Joomla Media Manager works
 To look at how the media manager works we consider what happens when a user clicks on the Content / Media button in the administrator back-end, and describe the steps shown on the diagram. It's simplified a little; the sequence diagram which follows is a more exact representation. 
 
 ![Media Manager Overview](./_assets/media-overview.jpg "Media Manager Overview")
@@ -80,7 +84,7 @@ com_media->>media-manager.js:confirm delete
 media-manager.js->>User:remove file from display
 ```
 
-# Writing a Filesystem Plugin
+## Writing a Filesystem Plugin
 To write a Filesystem plugin you need to provide 2 classes:
 1. The Provider class, which implements `Joomla\Component\Media\Administrator\Provider\ProviderInterface` in administrator/components/com_media/src/Provider/ProviderInterface.php. This is straightforward, and you just copy the approach of the Local Filesystem plugin in plugins/filesystem/local/src/Extension/Local.php. The main plugin (Extension) class doubles as the Provider class.
 2. The Adapter class, which implements `Joomla\Component\Media\Administrator\Adapter\AdapterInterface` in administrator/components/com_media/src/Adapter/AdapterInterface.php. This is where the bulk of the work lies, as you have to implement based on your filestore the various types of file operations.
@@ -103,12 +107,12 @@ public function delete(string $path)
 }
 ```
 
-# Plugin Source Code
+## Plugin Source Code
 You can copy the source code below into a directory `plg_filesystem_restricted`, or download the complete plugin from [download restricted filesystem plugin](./_assets/plg_filesystem_restricted.zip).
 
 Once installed, remember to enable the plugin! You also need to create the `/restricted` folder within the root folder of your Joomla instance.
 
-## Manifest file
+### Manifest file
 
 ```php title="plg_filesystem_restricted/restricted.xml"
 <?xml version="1.0" encoding="UTF-8"?>
@@ -126,7 +130,7 @@ Once installed, remember to enable the plugin! You also need to create the `/res
 </extension>
 ```
 
-## Service Provider File
+### Service Provider File
 This is boilerplate code for instantiating the plugin via the Joomla Dependency Injection Container.
 
 ```php title="plg_filesystem_restricted/services/provider.php"
@@ -162,7 +166,7 @@ return new class () implements ServiceProviderInterface {
 };
 ```
 
-## Plugin / Provider class
+### Plugin / Provider class
 This has been adapted from the equivalent class in the Joomla Local filesystem plugin.
 
 ```php title="plg_filesystem_restricted/src/Extension/Restricted.php"
@@ -240,7 +244,7 @@ final class Restricted extends CMSPlugin implements ProviderInterface
 }
 ```
 
-## Adapter Class
+### Adapter Class
 For our Adapter class we extend the Joomla LocalAdapter and override the `delete` function. 
 
 ```php title="plg_filesystem_restricted/src/Adapter/RestrictedAdapter.php"

--- a/docs/building-extensions/plugins/joomla-4-and-5-changes.md
+++ b/docs/building-extensions/plugins/joomla-4-and-5-changes.md
@@ -2,7 +2,11 @@
 title: Joomla 4 and 5 Changes
 sidebar_position: 2
 ---
-# Key changes
+
+Joomla 4 and 5 Changes
+======================
+
+## Key changes
 In Joomla 4 a number of significant changes began to be introduced to the plugins area:
 1. Plugins were instantiated via the Dependency Injection Container, through the `services/provider.php` file. Previously plugins were run via the plugin's main php file.
 2. Plugins subscribed to the events which they wanted to get notified about. Previously you wrote a method whose name matched the name of the event, and Joomla used PHP reflection classes to determine when your method got called. With the subscription mechanism Joomla checks if your plugin implements `Joomla\Event\SubscriberInterface` and if so calls `getSubscribedEvents` to which the plugin returns the event types it wants to handle, and the method which Joomla should call:
@@ -31,10 +35,10 @@ To enable plugins to use Event classes before the full concrete event class coul
 
 This is what we're now going to look at in detail. 
 
-# Joomla 3 / 4 / 5 comparison
+## Joomla 3 / 4 / 5 comparison
 Let's take the example of `onContentPrepare` and consider how it has changed through these releases. 
 
-## Joomla 3
+### Joomla 3
 In Joomla 3 the event was triggered in `com_content` using
 ```php
 $dispatcher->trigger('onContentPrepare', array ('com_content.article', &$item, &$item->params, $offset));
@@ -52,7 +56,7 @@ return $value;
 
 The Joomla team have provided backward compatibility for plugins through releases 4 and 5, so this mechanism will still work. However it will likely disappear in Joomla 6, so you should not write any new plugins this way. 
 
-## Joomla 4
+### Joomla 4
 In Joomla 4 the event is triggered using:
 ```php
 $this->dispatchEvent(new Event('onContentPrepare', ['com_content.article', &$item, &$item->params, $offset]));
@@ -70,7 +74,7 @@ $result[] = $value;                              // add your return value into t
 $event->setArgument('result', $result);          // write back the updated result into the GenericEvent instance
 ```
 
-## Joomla 5
+### Joomla 5
 In Joomla 5 the event is triggered using:
 ```php
 $dispatcher->dispatch('onContentPrepare', new Content\ContentPrepareEvent('onContentPrepare', $contentEventArguments));
@@ -95,8 +99,8 @@ use Joomla\CMS\Event\Result\ResultAwareInterface;
 
 **If you're developing a developing a plugin to handle a `GenericEvent` then it's crucial to use the above mechanisms to avoid the plugin failing whenever the triggering code moves to using a concrete Event class.**
 
-# Other New Features
-## Priority
+## Other New Features
+### Priority
 To use a plugin priority other than the default, specify this in your response to `getSubscribedEvents`
 ```php
 public static function getSubscribedEvents(): array
@@ -109,7 +113,7 @@ public static function getSubscribedEvents(): array
 ```
 See the other values available in libraries/vendor/joomla/event/src/Priority.php. Use with caution though, as this will override any priority which the site administrator may want to set through ordering the plugins.
 
-## Stop Propagation
+### Stop Propagation
 To stop the propagation of an event to other plugins you can call
 ```php
 $event->stopPropagation();

--- a/docs/building-extensions/plugins/system-plugin-router-rules.md
+++ b/docs/building-extensions/plugins/system-plugin-router-rules.md
@@ -2,7 +2,11 @@
 title: System Plugin Router Rules
 sidebar_position: 5
 ---
-# Introduction
+
+System Plugin Router Rules
+==========================
+
+## Introduction
 This example of a system plugin illustrates the flexibility of Joomla in allowing developers to change how the routing within `com_content` works, without having to hack the Joomla code.  
 
 **WARNING: This is a system plugin, which is loaded every time Joomla runs, on both the site front-end and administrator back-end. If you have a PHP syntax error in it then you will get locked out of the Joomla administrator back-end, and will have to go into phpmyadmin (or equivalent) to set to 0 the `enabled` field within the plugin record in the `#__extensions` table. If you're not comfortable doing this then using this plugin is not recommended.**
@@ -21,7 +25,7 @@ If you're copying the code below, then you will need to write the following 5 fi
 
 For simplicity the plugin uses English only; if you want to make it multilingual you can change it as described in [basic content plugin](basic-content-plugin.md).
 
-## Manifest file
+### Manifest file
 
 ```xml title="plg_custom_menurule/custom_menurule.xml"
 <?xml version="1.0" encoding="utf-8"?>
@@ -40,7 +44,7 @@ For simplicity the plugin uses English only; if you want to make it multilingual
 </extension>
 ```
 
-## Service Provider file
+### Service Provider file
 This is standard boilerplate code for plugins for instantiating the plugin via the Dependency Injection Container. You just have to adapt the standard code for your own plugin (basically 3 lines, plus we inject the Application as we'll use that within the plugin).
 
 ```php title="plg_custom_menurule/services/provider.php"
@@ -65,7 +69,7 @@ return new class implements ServiceProviderInterface {
 };
 ```
 
-## Extension class file
+### Extension class file
 This is the entry point for the plugin. It registers to listen for the 'onAfterExtensionBoot' event, which is raised within `loadExtension` in libraries/src/Extension/ExtensionManagerTrait.php. Joomla runs this code every time it loads an extension, and this code:
 - runs the component's services/provider.php file to load it and its dependencies into the [component's child DIC](../../general-concepts/dependency-injection/extension-child-containers.md) 
 - triggers the 'onAfterExtensionBoot' event
@@ -105,7 +109,7 @@ class CustomMenurulePlugin extends CMSPlugin implements SubscriberInterface {
 }
 ```
 
-## Component Router
+### Component Router
 Because the RouterFactory will try to instantiate a component router with a fully qualified classname of `<namespace>\Site\Service\Router`, this defines the classname for our Router and the location of the PHP file. We make our Router class similar to that of `com_content` by extending the `com_content` Router class, but we change the `MenuRules` class which it attaches to be our own MenuRules class. 
 
 We also have to define the `getName` function to return the string "content", as this will be used in getting the relevant menuitems, namely those which are associated with `com_content`.
@@ -151,7 +155,7 @@ class Router extends \Joomla\Component\Content\Site\Service\Router
 
 ```
 
-## MenuRules class
+### MenuRules class
 We're now in a position to write our own rules for determining how the menuitem is chosen on which to base the `com_content` SEF URLs. What's below is an example of how you can modify the Joomla code in libraries/src/Component/Router/Rules/MenuRules.php. Because our rules class inherits from the Joomla rules class, you can write your own rules in the `preprocess` function, and if you can't find a suitable menuitem you can just drop back to the Joomla version by calling `parent::preprocess(&$query)`.
 
 This function differs from the standard Joomla router in a number of areas:
@@ -366,5 +370,5 @@ class MenuRules extends \Joomla\CMS\Component\Router\Rules\MenuRules
 }
 ```
 
-## Installation
+### Installation
 Once you have created the files above, then zip up the folder and install the extension. Then go into System / Plugins or System / Extensions and Enable the plugin. Experiment with `com_content` menuitems, categories and articles to see the difference in how the SEF URLs appear.

--- a/docs/building-extensions/templates/color-scheme.md
+++ b/docs/building-extensions/templates/color-scheme.md
@@ -1,4 +1,10 @@
-# Color scheme support
+---
+title: Color scheme support
+sidebar_position: 5
+---
+
+Color scheme support
+====================
 
 ...also known as "dark mode".
 
@@ -8,7 +14,7 @@ When color scheme changes (either automatically or through custom switch) the te
 to help to the extensions (such as the editor plugins) to load the appropriate dark/light theme. 
 Additionally, the event `joomla:color-scheme-change` should be triggered.
 
-#### Document attributes
+## Document attributes
 
 The following data attributes in the `<html>` element should be used within template that provides color scheme switch feature:
 
@@ -16,7 +22,7 @@ The following data attributes in the `<html>` element should be used within temp
 - `data-color-scheme="light"` When template uses the **Light** color scheme, which were changed either automatically or through custom switch. 
 - `data-color-scheme="dark"` When template uses the **Dark** color scheme, which were changed either automatically or through custom switch.
 
-#### JavaScript event
+## JavaScript event
 
 When the scheme changes the template should trigger a Custom event `joomla:color-scheme-change`, 
 to notify about color scheme changes (which were changed either automatically or through custom switch)

--- a/docs/general-concepts/acl/acl-access.md
+++ b/docs/general-concepts/acl/acl-access.md
@@ -2,7 +2,8 @@
 title: Access
 ---
 
-# How Joomla Access Works
+How Joomla Access Works
+=======================
 
 Joomla items such as Articles, Contacts and Menuitems have an Access field which is used in determining whether a user may or may not view that item. 
 
@@ -32,7 +33,7 @@ Because the User doesn't belong to User Group E, any item which has a red Access
 
 Following this approach you should see that the User should have visibility to item 5, but not to items 3 or 4. 
 
-# Coding Approach
+## Coding Approach
 It's important to understand that Joomla doesn't magically apply the Access rules to ensure website visitors see only what they should be allowed to see. It's up to you when you're coding your extension to follow the example of the core Joomla components and apply the Access framework to your extension. Joomla does provide library functions which enable you (and the developers of the core Joomla components and modules) to apply the Access rules easily. 
 
 When checking Access in your code, the easiest approach is to use the `User::getAuthorisedViewLevels` function:

--- a/docs/general-concepts/acl/acl-permissions.md
+++ b/docs/general-concepts/acl/acl-permissions.md
@@ -1,9 +1,13 @@
 ---
 title: Permissions
 ---
+
+Permissions
+===========
+
 Joomla has a very sophisticated permissions framework, and if you're not familiar with it you should view some introductory material first. I'd recommend the [Access Control List Tutorial](https://docs.joomla.org/J3.x:Access_Control_List_Tutorial) and the video [Joomla 3 ACL Explained with Randy Carey](https://www.youtube.com/watch?v=CFqXAc3orkY) (between 2 minutes and 32 minutes is the section to watch). Both of these related to Joomla 3, but ACL hasn't changed between Joomla version 3 and version 4 or 5.
 
-# Permissions - an implementation view
+## Permissions - an implementation view
 Permissions are held in the Joomla `#__assets` table, in the `rules` column. If you have a clean Joomla install, in the `assets` record for `com_content` (ie the record where the `name` column is "com_content") you'll have an entry in the `rules` column similar to (but probably not exactly the same as) the json string:
 ```
 {"core.admin":{"7":1},"core.manage":{"6":1},"core.create":{"3":1},"core.edit":{"4":1,"2":1},"core.edit.state":{"5":1},
@@ -26,7 +30,7 @@ The picture shows the permissions for the Registered user group, which on my Joo
 - "core.delete" - set to 0 - *Denied*
 Other permissions are not set, and so these default to *Inherited*. 
 
-# Permission Actions
+## Permission Actions
 These are the types of actions which users may perform. Most are self-evident, but some may require a little explanation.  
 
 "**core.admin**" - this is described as "Configure ACL & Options" at the component configuration level and "Super User" at the Global Configuration level. 
@@ -41,7 +45,7 @@ A user with "core.admin" permission at the Joomla site level (ie Global Configur
 
 "**core.manage**" - described as "Access Administration Interface". A user with this permission may access the administrator back-end and perform lower level administration functions such as checking in items. 
 
-# The Asset Hierarchy
+## The Asset Hierarchy
 ![Joomla Asset Hierarchy](_assets/asset-hierarchy.jpg "Joomla Asset Hierarchy")
 
 As shown in the diagram, assets are held in a hierarchy, implemented as a Nested Set structure in the `#__assets` table. This enables permissions to be set at a higher level, and then for these to ripple down to lower level items. 
@@ -52,7 +56,7 @@ For `com_content` the lowest level is the individual article, then going up we h
 - com_content permissions
 - global configuration permissions
 
-# How Joomla determines if a user may perform an action
+## How Joomla determines if a user may perform an action
 Let's consider how Joomla checks if a user may edit an article. Here are the steps (these are the logical steps - the actual is code is designed differently to be more performant):
 
 1. Decide on the permission - let's say in this case that it's "core.edit"
@@ -64,7 +68,7 @@ Let's consider how Joomla checks if a user may edit an article. Here are the ste
 - If no Denied value is found for any of the user's usergroups then if there's at least one entry for any of the user's usergroups which has a value 1 (Allowed) then the user is permitted to perform the action.
 - If there are no entries in any of the asset hierarchy rules for any of the user's usergroups then the user is not permitted to perform the action. 
 
-# Checking Permissions in your Extension
+## Checking Permissions in your Extension
 Joomla doesn't magically apply the permission rules to control what users may or may not do within your extension. It's up to you to determine which permission string is appropriate for an action, and call the Joomla library functions to check if the user has permissions to perform that action.
 
 For example, to check if a user may edit an article (with id = 22, say), use:

--- a/docs/general-concepts/categories/implementing-categories-in-components.md
+++ b/docs/general-concepts/categories/implementing-categories-in-components.md
@@ -2,7 +2,9 @@
 sidebar_position: 3
 title: Implementing Categories in your Component
 ---
-# Implementing Categories in your Component
+Implementing Categories in your Component
+=========================================
+
 It's quite straightforward to implement categories in a custom component. Here is a summary of what you have to do.
 
 ## Specify a category id column in your component's database table

--- a/docs/general-concepts/categories/using-categories-api.md
+++ b/docs/general-concepts/categories/using-categories-api.md
@@ -3,7 +3,8 @@ sidebar_position: 2
 title: Using the Categories API
 ---
 
-# Using the Categories API
+Using the Categories API
+========================
 
 ## Accessing the Categories class
 

--- a/docs/general-concepts/dashboard.md
+++ b/docs/general-concepts/dashboard.md
@@ -1,5 +1,6 @@
 Dashboard
-=======================
+=========
+
 It is common usage to insert a link into the component menu for direct access to your own component.
 This is done in the manifest file: 
 
@@ -10,8 +11,9 @@ This is done in the manifest file:
 	[.. ]
 	</administration>
 ```
-Add a dashboard to your component:
-==================================
+
+## Add a dashboard to your component:
+
 
 A parameter "dashboard" expands the menu entry to your component with a link to a dashboard. You can give this dashboard any name you want, but <strong> Note:</strong> use lowercase and only "-", never underscore for the dashboard name.
 my-example or example are correct, my_example, Com-MY_EXAMPLE are wrong.
@@ -35,7 +37,7 @@ The param dashboard
 ```
 Joomla provides now a dashboard for your component. You can add modules here using the <strong> position: cpanel-example </strong>. 
 
-## Dashboard title and icon 
+### Dashboard title and icon 
 
 Give your dashboard a name and an icon. Add this to your manifest file:
 
@@ -45,7 +47,7 @@ Give your dashboard a name and an icon. Add this to your manifest file:
 	</dashboards>
 ```
 
-## Submenu
+### Submenu
 If you want to address different views of your component, expand the menu with a submenu.  
 
 ```xml title="Submenu items"
@@ -63,7 +65,7 @@ If you want to address different views of your component, expand the menu with a
 </submenu>
 ```
 
-# Submenu Module on your Dashboard
+## Submenu Module on your Dashboard
 
 Your dashboard is empty and waits for modules to be filled in. If you want to add your submenu, you have to
 - add a folder presets to your component
@@ -73,7 +75,7 @@ Your dashboard is empty and waits for modules to be filled in. If you want to ad
 
 Presets are already used in the core, see examples the component com_menu.
 
-## The menu preset
+### The menu preset
 
 In a folder 'presets' create a preset file, name it example.xml. 
 
@@ -108,7 +110,7 @@ In a folder 'presets' create a preset file, name it example.xml.
 ```
 
 
-## Manifest file
+### Manifest file
 
 ```xml title="New folder in example.xml"
 	<administration>
@@ -130,7 +132,7 @@ In a folder 'presets' create a preset file, name it example.xml.
 	</administration>
 ```
 
-## install script
+### install script
 
 We suppose here that you have a install script in your component. If not, please read the doc for install scripts.
 

--- a/docs/general-concepts/database/delete-data.md
+++ b/docs/general-concepts/database/delete-data.md
@@ -3,7 +3,8 @@ sidebar_position: 5
 title: Delete Data from the Database
 ---
 
-# Deleting a Record
+Deleting a Record
+=================
 
 Use the delete method to remove records from the database.
 

--- a/docs/general-concepts/database/index.md
+++ b/docs/general-concepts/database/index.md
@@ -2,7 +2,8 @@
 title: Database
 ---
 
-# Introduction
+Introduction
+============
 
 Joomla provides a sophisticated database abstraction layer to simplify the usage for third party developers. New versions of the Joomla Platform API provide additional functionality which extends the database layer further, and includes features such as connectors to a greater variety of database servers and the query chaining to improve readability of connection code and simplify SQL coding.
 

--- a/docs/general-concepts/database/insert-data.md
+++ b/docs/general-concepts/database/insert-data.md
@@ -3,7 +3,10 @@ sidebar_position: 3
 title: Insert Data into the Database
 ---
 
-# The Query
+Insert Data into the Database
+=============================
+
+## The Query
 
 Joomla's database querying has changed since the new Joomla Framework was introduced "query chaining" 
 is now the recommended method for building database queries (although string queries are still supported).
@@ -40,9 +43,9 @@ Some of the more frequently used methods include; select, from, join, where and 
 such as insert, update and delete for modifying records in the data store. By chaining these and other method
 calls, you can create almost any query against your data store without compromising portability of your code.
 
-# Inserting a Record
+## Inserting a Record
 
-## Using SQL via the Query Object
+### Using SQL via the Query Object
 
 The `DatabaseQuery` class provides a number of methods for building insert queries,
 the most common being insert, columns and values.
@@ -76,7 +79,7 @@ $db->setQuery($query);
 $db->execute();
 ```
 
-## Using an Object
+### Using an Object
 
 The `DatabaseDriver` class also provides a convenient method for saving an object directly to the database
 allowing us to add a record to a table without writing a single line of SQL.

--- a/docs/general-concepts/database/query-results.md
+++ b/docs/general-concepts/database/query-results.md
@@ -3,7 +3,8 @@ sidebar_position: 2
 title: Query Results after Selecting Data from the Database
 ---
 
-# Query Results
+Query Results
+=============
 
 The database class contains many methods for working with a query's result set
 that you can get after [SELECT](select-data.md) queries.

--- a/docs/general-concepts/database/select-data.md
+++ b/docs/general-concepts/database/select-data.md
@@ -3,7 +3,8 @@ sidebar_position: 1
 title: Select Data from the Database
 ---
 
-# The Query
+Select Data from the Database
+=============================
 
 Since Joomla introduced support for a variety of database types in Joomla 1.6 - the recommended way of building database queries is through "query chaining" (although string queries will always be supported).
 

--- a/docs/general-concepts/database/update-data.md
+++ b/docs/general-concepts/database/update-data.md
@@ -3,7 +3,8 @@ sidebar_position: 4
 title: Update Data in the Database
 ---
 
-# Updating a Record
+Updating a Record
+=================
 
 ## Using SQL
 

--- a/docs/general-concepts/dependency-injection/DIC.md
+++ b/docs/general-concepts/dependency-injection/DIC.md
@@ -2,7 +2,10 @@
 title: The Dependency Injection Container
 sidebar_position: 2
 ---
-# The Dependency Injection Container
+
+The Dependency Injection Container
+==================================
+
 The Joomla Dependency Injection Container, DIC for short, is basically a repository of key-value pairs where: 
 - the key is a string which is (usually) the fully qualified name of a class or interface 
 - the value is an instance of the relevant class, or a function that returns an instance of that class.

--- a/docs/general-concepts/dependency-injection/basic-concept.md
+++ b/docs/general-concepts/dependency-injection/basic-concept.md
@@ -2,24 +2,33 @@
 title: Basic Concept
 sidebar_position: 1
 ---
-# Basic Concept
+
+Basic Concept
+=============
+
 The basic idea behind Joomla dependency injection is that developers should no longer get access to key Joomla class instances by calling
+
 ```php
 $obj = new JoomlaClass();
-or
+// or
 $obj = JoomlaClass::getInstance();
 ```
-Instead they should make a request to the Dependency Injection Container (DIC):
+
+Instead, they should make a request to the Dependency Injection Container (DIC):
+
 ```php
 $obj = $container( – please give me an instance of JoomlaClass – );
 ```
+
 or get an instance via the Application class or a Factory class which has been obtained from the DIC.
 
 The main reason for this is to enable better testing by making it easier to mock classes. If the code has multiple calls to `JoomlaClass::getInstance()` then it's hard to mock that class for testing.
 
 If instead the code always uses the DIC to get an instance of the class, then to mock it all we have to do is put the mocked class into the DIC instead of the real one. 
 To make it less obvious that a specific class is being requested we can ask instead for a class which meets a particular interface:
+
 ```php
 $obj = $container( – please give me an instance of a class that implements JoomlaInterface – );
 ```
+
 The DIC will then return either the real class or the mocked class, depending upon how it has been configured. However, using a class name versus an interface name has no bearing on the functionality; as we shall see, the key used for putting things into and getting things out of the DIC is just a string, so we just have to ensure that we use the same key string for both operations.

--- a/docs/general-concepts/dependency-injection/di-issues.md
+++ b/docs/general-concepts/dependency-injection/di-issues.md
@@ -2,25 +2,33 @@
 title: Dependency Injection Issues
 sidebar_position: 7
 ---
-# Dependency Injection Issues
+Dependency Injection Issues
+===========================
+
 Dependency Injection was introduced in Joomla 4, with the intention of removing direct access to most key classes via `getInstance()` calls, including via `Factory::` calls, and many of these API calls are deprecated in Joomla 4. Note that not all `getInstance()` calls are deprecated; examples which are not deprecated include `Uri::getInstance()` and `Filter\InputFilter::getInstance()`. 
 
 However, some issues do remain, which you should be aware of. Early versions of Joomla 5 still have a lot of these `getInstance` calls!
 
 ## Toolbar::getInstance()
+
 The `Toolbar` class is used for managing the buttons on the forms within the Joomla administrator back-end. The [Toolbar API](https://api.joomla.org/cms-4/classes/Joomla-CMS-Toolbar-Toolbar.html) documentation seems to suggest that we should replace 
+
 ```php
 $bar = Toolbar::getInstance('toolbar');
 ```
+
 with
+
 ```php
 $bar = Factory::getContainer()->get(ToolbarFactoryInterface::class)->createToolbar('toolbar');
 ```
+
 However, this currently won't work. The problem is that all the other Joomla code uses `getInstance('toolbar')` to access the Toolbar class, including the code in administrator/modules/mod_toolbar/mod_toolbar.php which renders the toolbar. The `getInstance` method keeps track of the Toolbar instances in a local static variable `$instances`, and returns the same Toolbar instance on repeated invocations.
 
 So if you use the second approach above you will get a Toolbar instance, but it won't be the same Toolbar instance as is stored in the `$instances` variable. It won't then be picked up by the Toolbar module, and so won't be rendered on the form. 
 
 ## Table::getInstance()
+
 Usually a Table instance is created by the MVCFactory class by calling `getTable()` in your Model. However, there are other cases where you may want one:
 - in your Table class code you may want another instance of your own component table to verify if an `alias` field entered by a user already exists
 - you may wish to access the Table class of another component - eg of com_categories.
@@ -30,16 +38,21 @@ Neither of these is possible via your component's MVCFactory class as
 - in your Table code by default you've no pointer back to MVCFactory class instance
 
 However, you can obtain instances by a more convoluted route, eg for com_content 
+
 ```php
 Factory::getApplication()->bootComponent('content')->getMVCFactory()->createTable($name, $prefix, $config);
 ```
+
 You can also use this method to boot your own component, to get another instance of your own Table.
 
 ## Categories::getInstance()
+
 If you use Categories in your component then you may want to use the Categories API, for example in a custom router, or in a site CategoryModel. The old method of calling
+
 ```php
 $categories = Categories::getInstance(...); 
 ```
+
 is deprecated.
 
 You can get a CategoryFactory from your child DIC when you instantiate your Extension, but unfortunately it's not passed down via the MVCFactory class to your Model. One possible solution is to store the CategoryFactory reference as a static variable of your Extension class, as described in [Implementing Categories in your Component](../categories/implementing-categories-in-components.md).

--- a/docs/general-concepts/dependency-injection/extension-child-containers.md
+++ b/docs/general-concepts/dependency-injection/extension-child-containers.md
@@ -2,7 +2,10 @@
 title: Extensions and Child Containers
 sidebar_position: 4
 ---
-# Extensions and Child Containers
+
+Extensions and Child Containers
+===============================
+
 Whenever Joomla boots an extension it creates a child DIC, solely for use of that extension. It's shown diagrammatically below.
 
 ![Child DIC](_assets/child-dic.jpg "Child DIC")
@@ -16,6 +19,7 @@ From Joomla version 4 the Joomla developers are requesting that extension develo
 2. The extension class is retrieved from the child DIC, creating an instance of the class
 
 Let's look at a minimal example of this for com_example, with namespace Mycompany\Component\Example.
+
 ```php
 use Joomla\CMS\Extension\ComponentInterface;
 use Joomla\DI\Container;
@@ -35,33 +39,42 @@ return new class implements ServiceProviderInterface {
     }
 };
 ```
+
 We can see that when Joomla does a `require` of this php file, then it will return a class instance:
+
 ```php
 $provider = require $path;  // $path points to the relevant services/provider.php file
 ```
+
 The variable `$provider` then points to an object which is an instance of this anonymous class. Also the class implements `Joomla\DI\ServiceProviderInterface`, which basically means that it has a method called `register` with the above signature.
 
 When next Joomla does 
+
 ```php
 if ($provider instanceof ServiceProviderInterface) {
     $provider->register($container);
 ```
+
 the `register` function will be called, which will put into the child DIC an entry with
 - key =  ComponentInterface::class – this is just a PHP shorthand way of specifying the string 'Joomla\CMS\Extension\ComponentInterface'
 - value = a function which returns a new instance of ExampleComponent, which is the [Extension class](../extension-and-dispatcher/extension-component.md) of `com_example`
 
 Then when  Joomla executes the code:
+
 ```php
 $extension = $container->get($type);
 ```
+
 the function above will run and will return a new instance of `ExampleComponent`. 
 
 You can follow through the Joomla code yourself in libraries/src/Extension/ExtensionManagerTrait.php, and confirm that the above pattern also applies to modules and plugins. 
 
 Notice also the following line in that file:
+
 ```php
 if ($extension instanceof BootableExtensionInterface) {
             $extension->boot($container);
         }
 ``` 
+
 So if the Extension class implements `BootableExtensionInterface` then Joomla will immediately call the `boot` function of the Extension instance, as described in the [Extension documentation](../extension-and-dispatcher/extension-component.md).

--- a/docs/general-concepts/dependency-injection/jconfig-example.md
+++ b/docs/general-concepts/dependency-injection/jconfig-example.md
@@ -2,7 +2,9 @@
 title: JConfig Example
 sidebar_position: 3
 ---
-# JConfig Example
+JConfig Example
+===============
+
 Early in its initialisation phase Joomla initialises the dependency injection container (DIC) by calling `createContainer()` which is in library/src/Factory.php. This results in the `register()` function being called in each of the class files in libraries/src/Service/Provider. By looking through those files you can see what gets put into the DIC upon initialisation. 
 
 Let's look at library/src/Service/Provider/Config.php, which sets up the configuration class `JConfig`. Here's what gets executed when the `register()` function is called:
@@ -26,10 +28,13 @@ $container->alias('config', 'JConfig')
         true
     );
 ```
+
 Here's an explanation of the code:
+
 ```php
 $container->alias('config', 'JConfig')
 ```
+
 This sets up an alias in the DIC so that you can call `$container->get('config')` as well as `$container->get('JConfig')`. Notice that the return value of this function is again the `$container` so that you can chain function calls. 
 
 Next there's a call to `share()` passing 3 parameters:
@@ -40,9 +45,11 @@ Next there's a call to `share()` passing 3 parameters:
 Remember that `share()` is the same as `set()` with the `shared` parameter set to `true`, so that the same class instance is going to be returned for each `get('JConfig')` call.
 
 When some part of the Joomla code calls 
+
 ```php
 $container->get('JConfig')
 ```
+
 then the function passed as parameter 2 above will be executed. 
 
 The Joomla global configuration is held in the `JConfig` class in configuration.php in the top level folder of your Joomla instance, so that function does the following:
@@ -54,15 +61,18 @@ The Joomla global configuration is held in the `JConfig` class in configuration.
 As this DIC entry is shared, the Registry instance will be stored in the DIC and will be returned on subsequent calls to `get('JConfig')`.
 
 So you can obtain the global configuration parameters by 
+
 ```php
 use Joomla\CMS\Factory;
 $container = Factory::getContainer();
 $container->get('JConfig');   // or ...
 $container->get('config');
 ```
+
 These calls go directly to the DIC to obtain the shared JConfig instance.
 
 Or you can obtain them via the Application instance, which has already got them from the DIC:
+
 ```php
 use Joomla\CMS\Factory;
 $application = Factory::getApplication();

--- a/docs/general-concepts/dependency-injection/modules-and-plugins.md
+++ b/docs/general-concepts/dependency-injection/modules-and-plugins.md
@@ -2,11 +2,15 @@
 title: Modules and Plugins
 sidebar_position: 6
 ---
-# Modules and Plugins
+Modules and Plugins
+===================
+
 The service provider files for modules and plugins are considerably more straightforward than those for components. If you look through your Joomla instance modules and plugins folders then you'll find several examples of services/provider.php files.
 
 ## Modules
+
 For example, for mod_breadcrumbs in Joomla 5 we have:
+
 ```php
 use Joomla\CMS\Extension\Service\Provider\Module;
 
@@ -18,6 +22,7 @@ public function register(Container $container): void
     $container->registerServiceProvider(new Module());
 }
 ```
+
 This module uses the standard Joomla\CMS\Extension\Service\Provider\Module class to generate its extension class \Joomla\CMS\Extension\Module. 
 
 It has 2 dependencies:
@@ -25,7 +30,9 @@ It has 2 dependencies:
 2. It uses a HelperFactory to find its helper file in src/Helper/BreadcrumbsHelper.php
 
 ## Plugins
+
 For example for the custom field color plugin in plugins/fields/color
+
 ```php
 use Joomla\Plugin\Fields\Color\Extension\Color;
 
@@ -45,6 +52,7 @@ public function register(Container $container)
     );
 }
 ```
+
 The plugin's Extension class is Color, which gets instantiated with 2 parameters being passed into its constructor:
 - the EventDispatcher class – this is obtained from the parent DIC, having been originally put into it from libraries/src/Service/Provider/Dispatcher.php when Joomla initialised
 - the plugin stdClass object which Joomla has traditionally used to store plugin data (id, name, type and params).

--- a/docs/general-concepts/dependency-injection/registering-subdependencies.md
+++ b/docs/general-concepts/dependency-injection/registering-subdependencies.md
@@ -2,13 +2,18 @@
 title: Registering Subdependencies
 sidebar_position: 5
 ---
-# Registering Subdependencies
+
+Registering Subdependencies
+===========================
+
 The final aspect of understanding the service provider files is registering subdependencies. The two-step process for loading extensions, which was described partially in the previous section, is really as follows:
 1. The extension class is entered into child DIC and any dependencies of the Extension class are registered (ie entered into the child DIC)
 2. The extension class is retrieved from the child DIC, creating an instance of the class. And any subdependencies of the Extension class are retrieved from the DIC, with the Extension instance storing pointers to those dependent objects, for when it needs them. 
 
 ## Minimal services/provider.php file
+
 Let's look at a minimal example for com_example, namespace Mycompany\Component\Example. In this case we'll assume that com_example doesn't need its own `Extension` class and can just use the Joomla-supplied `MVCComponent` class as its `Extension`. So this services/provider.php file is about as minimalist as it gets for a basic component.
+
 ```php
 use Joomla\CMS\Extension\ComponentInterface;
 use Joomla\CMS\Extension\MVCComponent;
@@ -33,6 +38,7 @@ return new class implements ServiceProviderInterface {
     }
 };
 ```
+
 Here we have included a few additional lines in the services/provider.php file, which relate to classes which will be needed by the com_example `Extension` instance
 - a DispatcherFactory will be needed to create the Dispatcher class instance, and then Joomla will call `dispatch()` on this Dispatcher object, as the next step in running the component
 - an MVCFactory will be needed to create the Controller, View, Model and Table class instances on behalf of the component.
@@ -42,6 +48,7 @@ The two `registerServiceProvider` calls result in the two dependencies being loa
 Then when component is instantiated there are `get` calls to obtain instances of these two Factory classes from the child DIC. 
 
 ## Duplicate Class Warning!
+
 Warning! Be aware that there are classnames here which have the same final part of the FQN:
 
 ComponentDispatcherFactory:
@@ -55,65 +62,86 @@ MVCFactory:
 In each case the latter is the true "Factory" class, the former is the service provider class which enables the true Factory class to be instantiated via the DIC. To try and reduce confusion, the FQNs of the service provider classes are used above.
 
 ## Resolving the ComponentDispatcherFactory Dependency
+
 In the second step, when Joomla calls `get(ComponentInterface::class)` the Extension class (the MVCComponent class in this example) is instantiated and the dependencies resolved. 
 
 Let's look first at the ComponentDispatcherFactory
+
 ```php
 $component = new MVCComponent($container->get(ComponentDispatcherFactoryInterface::class));
 ```
+
 The code `$container->get(ComponentDispatcherFactoryInterface::class)` runs the function in the child DIC associated with the ComponentDispatcherFactoryInterface::class key. This function is found in libraries/src/Extension/Service/Provider/ComponentDispatcherFactory.php, and the object returned:
+
 ```php
 new \Joomla\CMS\Dispatcher\ComponentDispatcherFactory($this->namespace, $container->get(MVCFactoryInterface::class))
 ```
+
 gets passed into the MVCComponent constructor as a parameter. The component class Joomla\CMS\Extension\MVCComponent inherits from Joomla\CMS\Extension\Component, and in the constructor of the latter it stores a reference to the passed-in ComponentDispatcherFactory:
+
 ```php
 public function __construct(ComponentDispatcherFactoryInterface $dispatcherFactory)
 {
     $this->dispatcherFactory = $dispatcherFactory;
 }
 ```
+
 And it also has a function `getDispatcher` which retrieves it, and uses it to instantiate a Dispatcher class:
+
 ```php
 public function getDispatcher(CMSApplicationInterface $application): DispatcherInterface
 {
     return $this->dispatcherFactory->createDispatcher($application);
 }
 ```
+
 Let's take another look at the line when the ComponentDispatcherFactory is instantiated:
+
 ```php
 new \Joomla\CMS\Dispatcher\ComponentDispatcherFactory($this->namespace, $container->get(MVCFactoryInterface::class))
 ```
+
 Here the code is also getting the MVCFactory instance out of the child DIC; the ComponentDispatcherFactory has in turn a dependency on the MVCFactory. Why is this? As described in the [Dispatcher documentation](../extension-and-dispatcher/dispatcher-component.md) whenever the Dispatcher's `dispatch` function is called it analyses the *task* parameter of the URL, to decide which Controller class to instantiate. So it stores the MVCFactory object passed in its constructor so that it can later use it to create the Controller class:
+
 ```php
 $controller = $this->mvcFactory->createController(...);
 $controller->execute($task);
 ```
+
 So the ComponentDispatcherFactory gets MVCFactory out of the DIC, stores a reference to it, and then passes it down to the Dispatcher class when instantiates it. Its code is in libraries/src/Dispatcher/ComponentDispatcherFactory.php.
 
 ## Resolving the MVCFactory Dependency
+
 This follows a pattern similar to that of the ComponentDispatcherFactory dependency.
 
 The dependency is registered with the line:
+
 ```php
 $container->registerServiceProvider(new Joomla\CMS\Extension\Service\Provider\MVCFactory('\\Mycompany\\Component\\Example'));
 ```
+
 which causes the `register` function in libraries/src/Extension/Service/Provider/MVCFactory.php to be run on an instance of that class. If you look at this file you'll see that the MVCFactory has several dependencies, all of which will get resolved by obtaining entries from the parent DIC.
 
 The second step involves instantiating the Extension class and resolving its dependencies:
+
 ```php
 $component = new MVCComponent($container->get(ComponentDispatcherFactoryInterface::class));
 $component->setMVCFactory($container->get(MVCFactoryInterface::class));
 ```
+
 In the first line the Extension class (MVCComponent) gets instantiated, with the ComponentDispatchFactory instance being passed into the constructor (as we saw above).
 
 In the second line the code `$container->get(MVCFactoryInterface::class` obtains the MVCFactory instance from the child DIC, and then a reference to it is stored locally through it being passed to `setMVCFactory`. This function is available to `MVCComponent` via the trait Joomla\CMS\MVC\Factory\MVCFactoryServiceTrait, which is used in MVCComponent, and which contains the lines:
+
 ```php
 public function setMVCFactory(MVCFactoryInterface $mvcFactory)
 {
     $this->mvcFactory = $mvcFactory;
 }
 ```
+
 ## Namespaces parameters
+
 You will have noticed that the namespace '\Mycompany\Component\Example' gets passed as a parameter into several classes constructors. (By the way, this is exactly the same PHP string as its equivalent with double backslashes instead of single backslashes).
 
 The reason for this is that these Factory class instances have responsibility for instantiating various classes on behalf of the component: 
@@ -121,11 +149,13 @@ The reason for this is that these Factory class instances have responsibility fo
 - the MVCFactory will instantiate Controller, View, Model and Table classes
 
 For example, the `createDispatcher` function of the ComponentDispatcherFactory looks to see if there's a specific Dispatcher class for com_example by forming a class name:
+
 ```php
 $className = '\\' . trim($this->namespace, '\\') . '\\' . $name . '\\Dispatcher\\Dispatcher';
 ```
+
 (where `$name` is 'Site' or 'Administrator') and seeing if that class exists. If it doesn't then it instantiates the default Joomla\CMS\Dispatcher\ComponentDispatcher class. 
 
-Similarly the MVCFactory uses the namespace to work out the fully qualified classnames of the com_example Controller, View, Model and Table classes in order to instantiate them. 
+Similarly, the MVCFactory uses the namespace to work out the fully qualified classnames of the com_example Controller, View, Model and Table classes in order to instantiate them. 
 
 This is one reason why a child DIC is necessary. Over the course of responding to an HTTP request Joomla will instantiate several extensions, each with their dependencies. As Joomla uses common keys – eg ComponentInterface::class for components – child DICs are necessary to separate out the entries for each extension.

--- a/docs/general-concepts/extension-and-dispatcher/dispatcher-component.md
+++ b/docs/general-concepts/extension-and-dispatcher/dispatcher-component.md
@@ -2,13 +2,17 @@
 title: Dispatcher Class for Components
 sidebar_position: 2
 ---
-# Dispatcher Class for Components
+Dispatcher Class for Components
+===============================
+
 The Dispatcher class comes into play whenever Joomla wants to run a component in order to capture the output to display on the web page. The class has one main function: `dispatch()`, which will run the component.
 
 So to run a component you first get its Extension class then:
+
 ```php
 $extension->getDispatcher()->dispatch();
 ```
+
 How the Extension class gets the Dispatcher class instance via the `getDispatcher()` call is covered in the Dependency Injection documentation; you will find the code for `getDispatcher()` in libraries/src/Extension/Component.php - the Component class in this file is in the inheritance chain of the Extension instance. 
 
 (You may be wondering why isn't there just a dispatch() function in the Extension class, rather than having this additional Dispatcher class. I think it's because the Joomla designers wanted a common Extension / Dispatcher pattern among components, modules and plugins, and the Dispatcher class for plugins is a lot more complex.)

--- a/docs/general-concepts/extension-and-dispatcher/extension-component.md
+++ b/docs/general-concepts/extension-and-dispatcher/extension-component.md
@@ -2,7 +2,10 @@
 title: Extension Class for Components
 sidebar_position: 1
 ---
-# Extension Class for Components
+
+Extension Class for Components
+==============================
+
 There are a number of occasions where other Joomla code would want to interact with our component, for example
 - the router might want to use our component's custom router to parse and build SEF routes
 - if our component supports categories, then `com_categories` will want to display on the categories view a summary by category containing the number of items with that category, split by published status
@@ -21,6 +24,7 @@ In Joomla 4 this is streamlined:
 ![Joomla 4 component access](_assets/extension-joomla4.jpg "Accessing a component in Joomla 4")
 
 From Joomla 4 components get a handle on our `com_example` component by calling:
+
 ```php
 $extension = $app->bootComponent("com_example");
 ```
@@ -28,13 +32,17 @@ $extension = $app->bootComponent("com_example");
 They can then call their required function on this Extension instance. 
 
 Immediately after the component Extension class is instantiated the Joomla library code will call your Extension's `boot` function, passing your child Dependency Injection Container instance:
+
 ```php
 $extension->boot($container);
 ```
+
 This is just an opportunity to let you do, well, really, whatever you like. Sometimes it's used to set up particular classes for using with `HtmlHelper::_()` calls. Or you can use it to save a reference to your child DIC (which can be hard to get otherwise). 
 
 After the first instantiation of your component Joomla caches the instance, and if there is another call to 
+
 ```php
 $extension = $app->bootComponent("com_example");
 ```
+
 it just returns your Extension instance, rather than performing the class instantiation and calling of `boot()` again. You can even call `bootComponent` passing your own component, if you need to get a reference to your own Extension object. 

--- a/docs/general-concepts/extension-and-dispatcher/extension-dispatcher-module.md
+++ b/docs/general-concepts/extension-and-dispatcher/extension-dispatcher-module.md
@@ -2,13 +2,18 @@
 title: Extension and Dispatcher Classes for Modules
 sidebar_position: 3
 ---
-# Extension and Dispatcher Classes for Modules
+
+Extension and Dispatcher Classes for Modules
+============================================
+
 The Extension and Dispatcher classes for modules perform a similar role to those for components, but they're simpler because Joomla instantiates these classes just for the purpose of executing the module to capture the output (aka rendering the module). 
 
 The Extension class instance is accessed in a similar way 
+
 ```php
 $module = $app->bootModule($moduleName, $applicationName);
 ```
+
 where `$moduleName` is the name of the module (eg 'mod_example') and `$applicationName` is 'site' or 'administrator'.
 
 The default module Extension class is defined in libraries/src/Extension/Module.php, and really just provides a mechanism to get to other classes:
@@ -16,9 +21,11 @@ The default module Extension class is defined in libraries/src/Extension/Module.
 - the module's own helper class (via a HelperFactory object)
 
 Similar to components, the module Dispatcher class contains the `dispatch()` function, which is used to run the module's code.
+
 ```php
 $module->getDispatcher($mod, $app)->dispatch();
 ```
+
 Here `$mod` is a PHP stdClass object representing the module, including data such as the module name, module id, module title, template position, and `$app` is the Application instance.
 
 The default module Dispatcher class is defined in libraries/src/Dispatcher/ModuleDispatcher.php
@@ -32,7 +39,7 @@ The Joomla code within the Dispatcher class makes available to the module copies
 
 Unlike in Joomla 3, from Joomla 4 these data items are copies, so if you change them you're not changing the original data items. 
 
-In general you're likely to find that you can use the default module Extension and Dispatcher classes, and you can just provide (eg for mod_example)
+In general, you're likely to find that you can use the default module Extension and Dispatcher classes, and you can just provide (eg for mod_example)
 - the module manifest XML file – mod_example.xml
 - the module entry point file – mod_example.php, just containing PHP code rather than a class
 - a module helper file (with code to obtain the required data) – a namespaced class under src/Helper/

--- a/docs/general-concepts/extension-and-dispatcher/extension-dispatcher-plugin.md
+++ b/docs/general-concepts/extension-and-dispatcher/extension-dispatcher-plugin.md
@@ -2,7 +2,10 @@
 title: Extension and Dispatcher Classes for Plugins
 sidebar_position: 4
 ---
-# Extension and Dispatcher Classes for Plugins
+
+Extension and Dispatcher Classes for Plugins
+============================================
+
 The equivalent classes for plugins are a little different.
 
 For plugins the Extension class is your plugin code, where you specify the events which want to subscribe to, and the code to execute when that event is triggered. See the plugin documentation for more details.

--- a/docs/general-concepts/forms-fields/custom-fields-overview.md
+++ b/docs/general-concepts/forms-fields/custom-fields-overview.md
@@ -2,14 +2,19 @@
 sidebar_position: 2
 title: Custom Fields Overview
 ---
-# Custom Fields Overview
+Custom Fields Overview
+======================
+
 You can define your own type of field (eg "mycustom") which you can then reference in your form definition XML file:
+
 ```xml
 <field type="mycustom" … />
 ```
+
 To do this you should extend the `\Joomla\CMS\Form\FormField` which is found in libraries/src/Form/Formfield.php, or you can extend one of the [standard form field types](https://docs.joomla.org/Standard_form_field_types) which extends `FormField`. 
 
 When you define your custom form you will also need to include an `addfieldprefix` attribute in your form XML file, so tell Joomla where to find the field definition. For example, if you have
+
 ```php
 namespace Mycompany\Component\Example\Administrator\Field;
 class MycustomField extends FormField {
@@ -17,10 +22,13 @@ class MycustomField extends FormField {
    // including the above is still common practice, but not now necessary with namespaced classes
 …
 ```
+
 then you should have
+
 ```xml
 <field addfieldprefix ="Mycompany\Component\Example\Administrator\Field" type="mycustom" … />
 ```
+
 You can include the `addfieldprefix` attribute either at the `<field>` level or inside a tag which encloses the `<field>` tag.
 
 ## Joomla Field Design Overview

--- a/docs/general-concepts/forms-fields/form-fields/index.md
+++ b/docs/general-concepts/forms-fields/form-fields/index.md
@@ -2,10 +2,15 @@
 sidebar_position: 1
 title: Standard Form Fields
 ---
-# Standard Form Fields
+
+Standard Form Fields
+====================
+
 ## Introduction
+
 Joomla provides an extensive range of type of fields which you can use in your forms. The source code for these field types is found in the libraries/src/Form/Field directory, and nearly all of these are described at [Joomla standard form fields](https://docs.joomla.org/Standard_form_field_types).
 To use one of these in your form you simply set it as the `type`, as in the following example:
+
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <form>
@@ -15,6 +20,7 @@ To use one of these in your form you simply set it as the `type`, as in the foll
   />
 </form>
 ```
+
 The detailed descriptions of the [standard form field types](https://docs.joomla.org/Standard_form_field_types) also include the attributes you can associate with each form field type; for example you can find a general set of attributes associated with ordinary text input fields at [text field type](https://docs.joomla.org/Text_form_field_type).
 
 If you look at the list of standard form file types you'll see that they fall into a few different categories:
@@ -35,6 +41,7 @@ Many of the attributes of the fields in the form definition XML file map directl
 **class** - maps to the HTML class attribute of the field. It is used to define the [client-side validation](../../forms/client-side-validation.md) to be applied, in addition to the normal use by CSS
 
 **showon** - this controls whether a field appears in the form, dependent upon the value of another field. For example,
+
 ```xml
 <field name="radiofield" type="radio" default="1" >
   <option value="1">No showon</option>
@@ -42,6 +49,7 @@ Many of the attributes of the fields in the form definition XML file map directl
 </field>
 <field name="textfield" type="text" showon="radiofield:2"/>
 ```
+
 The text field is shown only if the radio field is set to 2. The condition can include operators `[AND]` or `[OR]`, as demonstrated in the [sample component code](../_assets/com_sample_form_field.zip) available for download. You can also use
 - `showon="radiofield!:2"` - shown if the value of `radiofield` is not equal to 2
 - `showon="somefield!:"` - shown if `somefield` has a value - ie it's not blank/null.

--- a/docs/general-concepts/forms-fields/standard-form-fields.md
+++ b/docs/general-concepts/forms-fields/standard-form-fields.md
@@ -2,10 +2,15 @@
 sidebar_position: 1
 title: Standard Form Fields
 ---
-# Standard Form Fields
+
+Standard Form Fields
+====================
+
 ## Introduction
+
 Joomla provides an extensive range of type of fields which you can use in your forms. The source code for these field types is found in the libraries/src/Form/Field directory, and nearly all of these are described at [Joomla standard form fields](https://docs.joomla.org/Standard_form_field_types).
 To use one of these in your form you simply set it as the `type`, as in the following example:
+
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <form> 
@@ -15,6 +20,7 @@ To use one of these in your form you simply set it as the `type`, as in the foll
         />
 </form>
 ```
+
 The detailed descriptions of the [standard form field types](https://docs.joomla.org/Standard_form_field_types) also include the attributes you can associate with each form field type; for example you can find a general set of attributes associated with ordinary text input fields at [text field type](https://docs.joomla.org/Text_form_field_type).
 
 If you look at the list of standard form file types you'll see that they fall into a few different categories:
@@ -26,6 +32,7 @@ If you look at the list of standard form file types you'll see that they fall in
 5. the `subform` type provides the ability to include a "subform" consisting of a group of fields, usually defined in a separate XML file. This group of elements can be repeated. There is an example of a `subform` in the [sample component](./_assets/com_sample_form_field.zip) 
 
 ## Attributes
+
 Many of the attributes of the fields in the form definition XML file map directly to HTML field attributes, and don't require any further explanation. The descriptions below relate to attributes where the meaning may not be totally clear.
 
 **validate** - is used to define the server-side validation to be applied; see the section on [server-side validation](../forms/server-side-validation.md)

--- a/docs/general-concepts/forms/client-side-validation.md
+++ b/docs/general-concepts/forms/client-side-validation.md
@@ -2,33 +2,44 @@
 sidebar_position: 4
 title: Client-side Validation
 ---
-# Client-side Validation
+
+Client-side Validation
+======================
+
 Client-side validation is performed by javascript running in the user's browser. However, it's important to highlight that this is not sufficient to make your website secure, as hackers can use utilities such as curl to send form data directly to your server, bypassing your validation. So you always need robust server-side validation.
 
 You can build client-side validation into your forms by doing the following 3 steps:
 1. Include the Joomla validate javascript library via the [Web Asset Manager](../web-asset-manager.md):
+
 ```php
 Factory::getApplication()->getDocument()->getWebAssetManager()->useScript('form.validate');
 ```
+
 If you're writing this line within a tmpl file, then you will usually have the `Document` available:
+
 ```php
 $this->document->getWebAssetManager()->useScript('form.validate');
+
 ```
 This line will result in the file media/system/js/fields/validate.js being sent to the client browser.
 
 2. Specify that you want validation to be performed on your form by adding the form-validate class:
+
 ```html
 <form class="form-validate"> ... </form>
 ```
 
 3. Specify the validation you want to be applied to a form field. You do this in your form definition XML file, by adding a class `validate-...` to a field. For example to specify that a telephone number field should be numeric:
+
 ```xml
 <field 
     name="telephone"
     type="telephone"
     class="inputbox validate-numeric"
-    ... />
+    …
+/>
 ```
+
 There are 4 types of validation which you can use:
 - validate-username
 - validate-password
@@ -40,29 +51,38 @@ These all use a javascript regular expression for checking the value entered by 
 Note that if you use a form field of `type="email"` then the `validate-email` class will automatically be added. (You still have to add steps 1 and 2 above for it to work though).
 
 Also if you specify that the field is required by eg:
+
 ```xml
 <field 
     name="telephone"
     type="telephone"
     required="true"
-    ... />
+    …
+/>
 ```
+
 then the javascript will also verify that a value has been entered into the field.
 
 The validation is performed whenever you click on a button on the form which relates to saving the data, for example:
+
 ```html
 <button type="button" class="btn btn-primary" onclick="Joomla.submitbutton('myform.submit')">Submit</button>
 ```
+
 and the validation is triggered within the javascript Joomla.submitbutton function. 
 
 You may also have a cancel button, which doesn't trigger the validation:
+
 ```html
 <button type="button" class="btn btn-primary" onclick="Joomla.submitbutton('myform.cancel')">Cancel</button>
 ```
+
 When the toolbar buttons are created only those which involve saving the data have a `class="form-validation"` attribute added to the button's HTML element. When a button is pressed then its `class` attribute is checked. If the `form-validation` class is present then the javascript `Joomla.submitbutton` function is called with the `validate` parameter set to `true`. Otherwise it is called with `validate` set to `false`.
 
 ## Custom Validation using pattern
+
 For fields such as `type="text"` and `type="telephone"` (which relate to an html `<input>` element) you can specify a javascript regular expression which the data entered by the user must match. For example
+
 ```xml
 <field 
     name="message"
@@ -70,14 +90,17 @@ For fields such as `type="text"` and `type="telephone"` (which relate to an html
     pattern="[^x]+"
     ... />
 ```
+
 will reject the data if there is a letter "x" within the field.
 
 **This applies to the client-side validation only! It has no effect on the server-side validation!**
 
 ## Custom Validation routine
+
 You can write your own javascript validation function as follows.
 
 1. Step 1 Write the js function. (Although a regex is used below, you're obviously not limited to this).
+
 ```js
 jQuery(function() {
     document.formvalidator.setHandler('message',
@@ -87,9 +110,11 @@ jQuery(function() {
         });
 });
 ```
+
 You should store all js files within the media folder, eg as media/js/validate-message.js within your component development directory structure. 
 
 2. Assuming you're writing this for a component `com_example`, include the js file within your media/joomla.asset.json list of assets. The code is dependent upon the `form.validate` entry and upon jquery:
+
 ```json
 {
       "name": "com_example.validate-message",
@@ -106,11 +131,13 @@ You should store all js files within the media folder, eg as media/js/validate-m
 ```
 
 3. Include your asset within your code, eg in your tmpl file:
+
 ```php
 $this->document()->getWebAssetManager()->useScript('com_example.validate-message');
 ```
 
 4. In your form definition XML file specify the field to which this validation should be applied
+
 ```xml
 <field 
     name="message"

--- a/docs/general-concepts/forms/how-forms-work.md
+++ b/docs/general-concepts/forms/how-forms-work.md
@@ -2,7 +2,11 @@
 sidebar_position: 1
 title: How Forms Work
 ---
-# Introduction
+
+How Forms Work
+==============
+
+## Introduction
 This page describes how you interact in general with the Joomla Form class and provides the code of a simple component which you can install to demonstrate use of this API. With the aid of the diagram below we'll walk through each stage of displaying a form through to handling the submitted data. 
 
 The section in pale yellow is the Joomla library code, specifically code relating to the Form class.
@@ -13,7 +17,7 @@ The rectangles with white backgrounds contain your extension code.
 
 At the outset, you need to define your form in XML using [Joomla Standard form field types](https://docs.joomla.org/Standard_form_field_types). See the component code below for an example. In basic terms, each field element in your XML file maps to an HTML (mostly "input") element in the form, with the XML field attributes mapping to the (input) element attributes. Many of the possible field attributes are listed in [Text form field type](https://docs.joomla.org/Text_form_field_type). 
 
-## Step 1 Loading the form
+### Step 1 Loading the form
 Step 1 is where the user has navigated to a webpage on which you display a form. 
 
 You first have to instantiate an instance of the Joomla Form class, and you do this by getting a FormFactory out of the [Dependency Injection Container](../dependency-injection/DIC.md) and calling `createForm`. You can do this with the code:
@@ -29,7 +33,7 @@ $form->loadFile("sample_form.xml");  // pass the file path and name of the XML f
 
 The Form object reads the file into memory (as a PHP SimpleXMLElement) and parses the XML to ensure it's valid. The SimpleXMLElement is represented by the blue rectangle with "xml" in the diagram.
 
-## Step 2 Providing Pre-fill Data
+### Step 2 Providing Pre-fill Data
 
 You provide values for any form element you wish. For example, if this form is being used to edit a record in the database, then you would pre-populate it with existing field values from the database. You can provide values by setting up an associative array `$data` where for each element of the array:
 - the key is the `name` of the field (in the xml file)
@@ -37,7 +41,7 @@ You provide values for any form element you wish. For example, if this form is b
 
 You pass the `$data` array as a parameter to the Form `bind` method, and Joomla Form then stores this data locally within the Form instance - represented by blue bars in the diagram. 
 
-## Step 3 Outputting the Form in HTML
+### Step 3 Outputting the Form in HTML
 
 You call `renderField`:
 ```php
@@ -47,17 +51,17 @@ where `$name` is the `name` of the field in the XML file, and you get returned t
 
 When outputting the form you also need to surround the input elements in a `<form>` element and add a `submit` button. 
 
-## Step 4 User Submitting the Form
+### Step 4 User Submitting the Form
 
 The user enters data into your HTML form and clicks on the `submit` button. The browser generates an HTTP POST request to the URL specified in the `<form>` element and passes to the server in an array called `myform` (or whatever `option` you chose previously) the values entered by the user; each element of the array keyed by the `name` attribute of the HTML input element.
 
 Joomla routes this POST through to your component. As this is a new HTTP request the previous Form instance no longer exists, so you have to repeat Step 1 to create a Form instance and load the XML form-definition file into memory. 
 
-## Step 5 Handling the HTTP POST Data
+### Step 5 Handling the HTTP POST Data
 
 In this step you process the submitted data. This involves 4 parts:
 
-### Getting the POST data
+#### Getting the POST data
 You can use the Joomla [Input](../input.md) functionality to get the data which the user entered. For example 
 ```php
 $app = Factory::getApplication();
@@ -65,27 +69,27 @@ $data = $app->input->post->get('myform', array(), "array");
 ```
 will read the POST `myform` parameters into an associative array.
 
-### Filtering the data
+#### Filtering the data
 It is vital to sanitize any data received to avoid injection attacks by hackers. With many of the [Input](../input.md) methods filtering is applied, but if you read them directly into an array (as above) then no filtering is applied, and you must do it explicitly using eg
 ```php
 $filteredData = $form->filter($data);
 ```
 This applies filtering on each of the input values. The filter applied to a field is governed by the "filter=..." attribute on that field in your form XML file, or if not present then the default filter will remove HTML tags etc from your data values. The possible filters are the classes which are in libraries/src/Form/Filter. Note that these form field filters are different from the [Input](../input.md) filters.
 
-### Validating the data
+#### Validating the data
 You validate the data which the user has entered by calling 
 ```php
 $result = $form->validate($data);
 ```
 Joomla compares the user-entered data with the validation you defined in your form XML file, and generates errors for fields which fail the validation. 
 
-### Providing user feedback
+#### Providing user feedback
 
 If there are validation errors then you should display those errors to the user, and redisplay the form, pre-populating the fields with the (filtered) data which the user entered previously.
 
 If there are no errors then you can confirm this to the user, and show the next web page. 
 
-# Sample Component Code
+## Sample Component Code
 Below is the code for a small component which you can install to demonstrate basic use of Joomla forms. Place the following 3 files into a folder called "com_sample_form1". Then zip up the folder to create com_sample_form1.zip and install this as a component on your Joomla instance.
 
 For simplicity this component uses the Joomla 3 way of defining a component, and this won't work under Joomla 5. If you want an equivalent which will work under Joomla 5 then you can download and install [this zip file](./_assets/com_sample_form1.zip).

--- a/docs/general-concepts/forms/manipulating-forms.md
+++ b/docs/general-concepts/forms/manipulating-forms.md
@@ -2,7 +2,11 @@
 sidebar_position: 4
 title: Manipulating Forms
 ---
-# Introduction
+
+Manipulating Forms
+==================
+
+## Introduction
 This section describes more advanced features of the Joomla Form API than is covered previously, and comprises the following aspects:
 
 - setting the file Path to enable Joomla to find your definition of your form(s), in the case where you don't follow the Joomla standards.
@@ -12,12 +16,12 @@ This section describes more advanced features of the Joomla Form API than is cov
 
 The section concludes with a sample component with examples of the above aspects. 
 
-# File Paths
+## File Paths
 By default Joomla will look in the …/forms folder of your component to find the XML definition of your form (and also the …/models/forms folder to maintain compatibility with Joomla 3), within the site files if your form is being displayed on the front end, or within the administrator files if your form is being displayed on the back end. The static function `addFormPath()` allows you to add a different directory to the list of directories which Joomla will search.
 
 (Similarly `addFieldPath()` allows you to define a different directory for any custom form field definitions (the default being …/models/fields in Joomla 3) and `addRulePath()` allows you to define a different directory for any custom validation rules (the default being …/models/rules in Joomla 3). However with namespacing introduced in Joomla 4 it's easier to add `addfieldprefix` and `addruleprefix` attributes to your form to enable Joomla to find custom field types and validation rules.)
 
-# Fieldsets
+## Fieldsets
 Fieldsets are associated with the `<fieldset name="myfieldset">` element in the XML definition of the form. The advantage of using fieldsets is that in your layout file you can use
 ```php
 $form->renderFieldset("myfieldset");
@@ -26,7 +30,7 @@ to render all the fields which have `<field>` elements inside the `<fieldset>` o
 
 A fieldset can be viewed as a set of fields which should be displayed together in a form, and are thus similar in concept to the HTML `<fieldset>` element. However, note that `renderFieldset()` does not output the HTML `<fieldset>` or related tags. 
 
-# Field Groups
+## Field Groups
 Field groups are associated with the `<fields name="mygroup">` element in the XML definition of the form. This affects the HTML name attribute which is assigned to HTML input elements of fields which are defined within the `<fields>` opening and closing tags in the XML form definition, and hence the name of the parameter as sent to the server in the HTTP POST request.
 
 If you specify the option `"control" => "myform"` when you set up your Form instance then input field values will be sent to the server in the HTTP POST request keyed like
@@ -52,14 +56,14 @@ The `$group` parameter which appears in several Form API methods refers to the `
 
 Note that `fieldsets` and `field groups` are independent. In your form XML definition you can have `<fields>` elements within `<fieldset>` elements, and also `<fieldset>` elements within `<fields>` elements. 
 
-# Dynamically Changing Forms
+## Dynamically Changing Forms
 If you have defined your form statically in an XML file, then once it's been loaded you can modify it dynamically in your PHP code using the Form APIs
 
 - adding further fields to your form by loading another form XML definition
 - modifying an existing field or fields,
 - removing a field or group of fields.
 
-## Adding Fields via form definition
+### Adding Fields via form definition
 To include additional definitions from a file into your form do
 ```php
 $form->loadFile($filename);
@@ -79,7 +83,7 @@ With both these functions you can pass additional parameters:
 
 In addition to the example in the sample code below, you can find examples of loading additional XML files in the core Joomla administrator `com_menu` code, related to when an admin is setting up site menu options. The basic options for a site menuitem are specified in the item.xml file in administrator/com_menus/models/forms, but in the com_menu model item.php code this is supplemented with options defined in the XML file which is in the layout directory related to the site page which is going to be displayed. 
 
-## Dynamically Setting Fields
+### Dynamically Setting Fields
 You can use `setField()` to add or replace a single field in the Form instance, and `setFields()` to add or replace several fields. To use these you create the XML relating to a field, then pass this to `setField()`
 ```php
 $xml = new SimpleXMLElement('<field name="newfield" … />');
@@ -93,17 +97,17 @@ If the `$replace` parameter is set to true then if an existing field with the sa
 
 If the `$replace` parameter is set to false and an existing field with the same field group and name is found, then the new field will be ignored. 
 
-## Setting Field Attributes and Values
+### Setting Field Attributes and Values
 `setFieldAttribute()` allows you to set / amend an attribute associated with a field. Note that the attribute refers to the Joomla field attribute, rather than the HTML attribute of the input element. For example, to set the HTML `placeholder` attribute you have to set the Joomla `hint` field attribute, and this works only if the Form Field type supports that attribute.
 
 The HTML `value` attribute is treated somewhat differently from other HTML attributes. As outlined in [How Forms Work](how-forms-work.md), in the Joomla Form instance the XML form structure (defined by the form definition XML file) is held separately from the form pre-fill data (passed in the `bind()` method). What is output in the `value` attribute of the HTML input element is primarily the default Joomla form field attribute (if supported for that field type), but this is overridden by any value specified for that field in the `bind()` call.
 
 You can thus set the default attribute using `setFieldAttribute()`, but to set the field value directly within the pre-fill data use `setValue()`.
 
-## Removing Fields
+### Removing Fields
 You can remove fields from the Form definition by calling `removeField()` to remove a specific field or `removeGroup()` to remove all the fields within a specified field group. 
 
-# Reflection Methods
+## Reflection Methods
 There are a number of methods which allow you to access various aspects of the Form instance data. Mostly these are fairly straightforward to understand, and only cases where it may not be totally clear are explained below.
 
 `getData()` returns as a Joomla Registry object the pre-fill data which has been set using the Form `bind()` call.
@@ -125,7 +129,7 @@ echo $fieldsets['myfieldset']->label;   // outputs "myfieldsetLabel"
 
 `getValue()` returns the value of the field you pass as a parameter, reading this from the data passed in the `bind()` call. It doesn't take account of the default attribute set against the field, which will get converted into the HTML field value attribute if no pre-fill data for that field is provided. 
 
-# Sample Component Code
+## Sample Component Code
 For this section you can download [this component zip file](./_assets/com_sample_form3.zip) and install it. It demonstrates several of the features described in this section. It doesn't follow the standard Joomla MVC pattern, and instead has all of the functionality in the single Extension class. This is because its aim is to highlight the APIs associated with manipulating forms. 
 
 After you have installed the file, navigate to your site home page and add the query parameter `?option=com_sample_form3` to run the component. This should display the form and allow you to enter data and submit the form. The comments in the code should make it clear what's going on.

--- a/docs/general-concepts/forms/mvc-etc.md
+++ b/docs/general-concepts/forms/mvc-etc.md
@@ -2,12 +2,16 @@
 sidebar_position: 2
 title: MVC and other considerations
 ---
-# Introduction
+
+MVC and other considerations
+============================
+
+## Introduction
 The way that the code of the previous section was written isn't the best approach if you are developing a genuine Joomla component. Instead you should follow the way that the Joomla core code is designed, in particular splitting your component into MVC - model, view, controller pattern. The revised component code `com_sample_form2` at the end of this section follows this approach. 
 
 This section describes MVC and other design patterns, and following these patterns generally make the component code easier to follow, especially in large components. 
 
-## Joomla MVC Split
+### Joomla MVC Split
 In general terms Joomla splits components into separate types of functionality:
 
 - the Controller contains the logic to decide how to respond to the HTTP request - in particular, deciding which View and Model to use
@@ -15,7 +19,7 @@ In general terms Joomla splits components into separate types of functionality:
 - the Model provides access to the data
 - the tmpl file is an extension of the View (it runs within the context of the View class instance and so has direct access to the `$this` variable of the View object). It outputs the HTML for the component, and it includes in the output the data which has been collated by the View. It's separate from the View code so that the HTML output can easily be overridden using a template override. 
 
-## Post/Request/Get Pattern
+### Post/Request/Get Pattern
 In Joomla all of the HTML output (such as the display of a form) is performed in response to an HTTP GET, following the [Post/Redirect/Get Pattern](https://en.wikipedia.org/wiki/Post/Redirect/Get) pattern. The sample code of the previous section doesn't follow this pattern, but instead outputs the validation errors and re-displays the form in the response to the HTTP POST request.
 
 To follow the Joomla pattern, in the code which handles the POST we should include a HTTP GET redirect to the form URL. As that GET will then be a new HTTP request/response we must store in the user session the data to be shown when the form is redisplayed, which includes the following 2 items:
@@ -37,7 +41,7 @@ Also, if the user enters data which successfully passes validation then `setUser
 
 Of course, although Joomla works using this pattern, you don't always have to follow it. For example, if you have a large amount of confirmation data which you want to output after a form has been successfully submitted then you can instead output this just as a response to the HTTP POST. 
 
-## Separate Controllers
+### Separate Controllers
 Joomla routes HTTP requests to separate Controllers based on the value of the *task* URL parameter sent in the request. This parameter is often set by Joomla core javascript based on the submit button, e.g. in the example below:
 ```php
 onclick="Joomla.submitbutton('myform.submit')"
@@ -46,10 +50,10 @@ When the `submit` button is clicked then the onclick listener calls the javascri
 
 In general the *task* parameter is of the form `<controller type>.<method>` and so in this case the HTTP POST containing the form data will be handled by the MyformController and its `submit` method. 
 
-## Joomla MVC Classes
+### Joomla MVC Classes
 Joomla provides feature-rich Controller, View and Model classes from which your component Controllers, Views and Models can inherit. The Model code in `com_sample_form2` inherits from FormModel which shields somewhat the Joomla Form API explained in the previous section. In this case our model calls the FormModel `loadForm()` method, and this method then executes a callback to our `loadFormData()` to provide the data to `bind()` to the form. So in the code there isn't a separate call to `bind()`.
 
-## Security Token
+### Security Token
 Joomla uses a security token on forms to prevent [CSRF attacks](https://en.wikipedia.org/wiki/Cross-site_request_forgery). The token is output in the layout file
 ```php
 <?php echo HTMLHelper::_('form.token'); ?>
@@ -60,10 +64,10 @@ $this->checkToken();
 ```
 If the token is found to be invalid then `checkToken()` outputs a warning and redirects the user back to the previous page. 
 
-## Validation
+### Validation
 This is covered in the following sections.
 
-# Sample Code
+## Sample Code
 For this section you can download [this component zip file](./_assets/com_sample_form2.zip) and install it. It has basically the same functionality as `com_sample_form1` in the previous section, but it has been redesigned according to the principles above. Although at first sight it may seem more complex, distributing the functionality in this way makes the code much easier to understand when the component becomes sizeable. 
 
 After you have installed the file, navigate to your site home page and add the query parameter `?option=com_sample_form2` to run the component. 
@@ -74,10 +78,10 @@ The files in the package are shown below.
 
 Here's a description of the functionality in each file.
 
-## admin/services/provider.php
+### admin/services/provider.php
 This is just a standard source file associated with Joomla [Dependency Injection](../dependency-injection/index.md). 
 
-## site/src/Controller/DisplayController.php
+### site/src/Controller/DisplayController.php
 The `display()` method of this class is what gets run when you initially navigate to the `com_sample_form2` component.
 ```php
 $model = $this->getModel('sample');
@@ -91,7 +95,7 @@ Then `setModel` is called so that the Model is available to the View code, with 
 
 Finally the View `display` method is called.
 
-## site/src/View/Sample/HtmlView.php
+### site/src/View/Sample/HtmlView.php
 In the View `display` function:
 ```php
 $this->form = $this->getModel()->getForm();
@@ -99,7 +103,7 @@ parent::display($tpl);
 ```
 it calls the `getForm` method of the (default) Model, then calls `parent::display()` which basically runs the tmpl/default.php file.
 
-## site/src/Model/SampleModel.php
+### site/src/Model/SampleModel.php
 In the Model `getForm` function we have:
 ```php
 $form = $this->loadForm(
@@ -126,7 +130,7 @@ $data = Factory::getApplication()->getUserState(
 ```
 The `setUserState` and `getUserState` functions store data in the Joomla `Session`, using a key which is here set to 'com_sample_form2.sample'. (You can see what's in the `Session` by setting "Debug System" to Yes in the Global Configuration parameters, then on a webpage click on the Joomla symbol in the bottom left of the page.)
 
-## site/tmpl/sample/default.php
+### site/tmpl/sample/default.php
 ```php
 <form action="<?php echo Route::_('index.php?option=com_sample_form2'); ?>"
     method="post" name="adminForm" id="adminForm" enctype="multipart/form-data">
@@ -150,7 +154,7 @@ There are a few points to note here:
 - we still need to explicitly include a hidden field with type `task`
 - the security token is included with `HtmlHelper::_('form.token')`. This will be sent as one of the POST parameters, and we need to check it when we handle the form submission.
 
-## site/src/Controller/MyformController.php
+### site/src/Controller/MyformController.php
 When the HTTP POST is received Joomla will route it to this Controller, and call the `submit` method.
 ```php
 $this->checkToken();

--- a/docs/general-concepts/guided-tours.md
+++ b/docs/general-concepts/guided-tours.md
@@ -1,11 +1,11 @@
 Guided Tours
-=======================
+============
 
 The simplest way to create tours for your organization or extensions is to create those tours with the tools provided in Joomla.
 
 Go to System (Manage section) -> Guided Tours.
 
-# Creating a new tour
+## Creating a new tour
 
 Starting with Joomla 5, an identifier is provided for each tour. This is not a required field but a value will always be present.
 This identifier is supposed to:
@@ -18,7 +18,7 @@ This identifier is supposed to:
 New in Joomla 5 as well is the creation of 2 separate language files. One for the tour and one for the steps of the tour.
 
 
-## The identifier
+### The identifier
 
 This is a unique string, very much like an alias for an article.
 The string should be formatted as:
@@ -38,7 +38,7 @@ The identifier corresponds to the `uid` column of the `#__guidedtour` table.
 On save or duplicate, a suggested identifier string is created.
 
 
-## The language files
+### The language files
 
 Not all tours need language files, especially if you are only targetting a one-language audience.
 But if you do need them, the files need to follow the new convention didacted by the identifier.
@@ -59,7 +59,7 @@ Reminder: the language keys can be anything BUT need to contain GUIDEDTOUR in th
 Language files do not need to be placed into administrator/language/[language]/. You can leave the files inside the extension's file structure.
 
 
-## The tour context
+### The tour context
 
 A `Component selector` parameter has been available ever since tours have been introduced in Joomla.
 The definition of 'component selector' slightly differs in Joomla 5.
@@ -75,7 +75,7 @@ Note that the Guided Tour component knows how to differentiate category tours fo
 There is no available tour when editing a specific module, plugin or template. That is where launching a tour from anywhere can become handy.
 
 
-# Launching a tour from any location
+## Launching a tour from any location
 
 Launching a tour from a different location than the Guided Tours module is as easy as adding the attribute `data-gt-uid` with the identifier of the tour.
 

--- a/docs/general-concepts/input.md
+++ b/docs/general-concepts/input.md
@@ -1,7 +1,11 @@
 ---
 title: Input
 ---
-# Joomla Input - Introduction
+
+Input
+=====
+
+## Joomla Input - Introduction
 The Joomla Input functionality provides an easy-to-use interface to obtaining and sanitising the data of several of the [PHP Superglobals](https://www.php.net/manual/en/language.variables.superglobals.php)
 - HTTP GET and POST parameters
 - routing parameters ("option", "view", "layout", etc) which are generated as a result of parsing the incoming SEF URL
@@ -9,20 +13,25 @@ The Joomla Input functionality provides an easy-to-use interface to obtaining an
 - PHP `$_SERVER` data - server and execution environment information. 
 
 To get started you have to get an instance of the Joomla `Input` class:
+
 ```php
 use Joomla\CMS\Factory;
 $input = Factory::getApplication()->getInput();
 ```
+
 If your code is in a Controller which inherits from Joomla\CMS\MVC\Controller\BaseController then this is already done for you, and stored in a protected variable `$input`, so you can just use `$this->input` instead of `$input` in the function calls below, without having to first set up `$input`.
 
 This document explains how you can then obtain the data items listed above.
 
-# Getting Individual Parameters with Filters
+## Getting Individual Parameters with Filters
+
 To get the value of a specific parameter use
+
 ```php
 $val = $input->get(param_name, default_value, filter);
 
 ```
+
 where: 
 - `param_name` is a string containing the name of the parameter you want to retrieve 
 - `default_value` is the value you want returned if the parameter is not found; it may be a string, integer, array, null, etc. – whatever you want. 
@@ -30,7 +39,8 @@ where:
 
 You can use this to obtain the value of any GET, POST or routing parameter - `Input` provides a common interface for obtaining any of these types of parameters. The method for obtaining specifically GET or POST parameters is described later in this documentation. 
 
-## Available Filters
+### Available Filters
+
 Below is a list of the available filters, together with a little explanation if appropriate. Filters can be specified in either lower or upper case, and if 2 filters are listed on the same line below, then it indicates that they are equivalent. If you need further details on a filter you can examine the source code in libraries/vendor/joomla/filter/src/InputFilter.php.
 
 - **"INT", "INTEGER"** - returns the first integer found in the parameter value. For example if the parameter is "abc123def456" then the return value from applying this filter would be 123 (as an integer). 
@@ -61,7 +71,8 @@ Below is a list of the available filters, together with a little explanation if 
 
 - **"USERNAME"** - filters out characters not permitted in a Joomla username 
 
-Alternatively instead of adding the filter you can use the Input type specific methods, for example: 
+Alternatively instead of adding the filter you can use the Input type specific methods, for example:
+
 ```php
 // Instead of:
 $input->get('name', '', 'STRING');
@@ -73,54 +84,68 @@ $input->get('memberId', 0, 'INT');
 // you can use:
 $input->getInt('memberId', 0);
 ```
+
 Except that `getArray()` is different; see below.
 
 To retrieve an object, you can use: 
+
 ```php
 $obj = $input->get(param_name, null, null);
 ```
 
-# Arrays
-Arrays come into play whenever 
+## Arrays
+
+Arrays come int o play whenever 
 - the data is sent from the client in the form of an array - as will be the case when you're using Joomla forms, and the form field data is sent to the server in the array (by default) `jform[]`.
 - the data sent is in the form of individual parameters, but you want to read them into an array.
 
 We'll consider the second type first.
 
-## Reading single parameters into an array
+### Reading single parameters into an array
+
 There are several methods for doing this, and they differ regarding the filter which is applied. 
 
-### Option 1
+#### Option 1
+
 ```php
 $value = $input->get('p1', array(), "array");
 ```
+
 As described above, the right hand side will return an array, and `$value[0]` will be set to the string value of p1. No filtering is applied to the parameter 'p1'.
 
-### Option 2
+#### Option 2
+
 ```php
 $values = $input->getArray();
 ```
+
 This will return all the parameters as an associative array, mapping parameter name to value. The "STRING" filter is applied to all the parameters, and value of each parameter is 
 - a string for individual parameters or 
 - an associative array for parameters which are arrays (with again the "STRING" filter being applied to each of its elements)
 
 **While the default filter for the `get()` method is "CMD", the default filter for the `getArray()` method is "STRING".**
 
-### Option 3
+#### Option 3
+
 You can specify which parameters you wish to retrieve into an array:
+
 ```php
 $values = $input->getArray(array('p1' => '', 'p2' => '', 'p3' => ''));
 ```
 This will return an associative array with elements 'p1', 'p2' and 'p3' pointing to their values. The "STRING" filter is applied to all the parameters. This is really the same as calling `getArray()` in Option 2, but restricting the set of parameters which will be returned.
 
-### Option 4
+#### Option 4
+
 In addition to specifying which parameters you wish to retrieve, you can also specify which filter to be applied to each:
+
 ```php
 $values = $input->getArray(array('p1' => 'string', 'p2' => 'int', 'p3' => 'cmd'));
 ```
+
 `$values` will be an associative array with elements 'p1', 'p2' and 'p3' pointing to their values. Each parameter will be filtered according to the requested filter, and the type will be set to match the filter (eg `$value['p2]` will be an `int`).
 
 You can also nest arrays to get more complicated hierarchies of values: 
+
 ```php
 $values = $input->getArray(array(
     'jform' => array(
@@ -130,25 +155,32 @@ $values = $input->getArray(array(
     )
 ));
 ```
-## Reading Array Parameters
+
+### Reading Array Parameters
 
 If the parameters you are reading are already in the form of an array, then there are several methods available to read them into a PHP array, some of them overlapping with the above. Again, the filter applied can vary. In the options below it is assumed that `jform` is an array of values being sent to the server.
 
-### Option 1
+#### Option 1
+
 ```php
 $value = $input->get('jform');
 ```
+
 `$value` will be an associative array, with keys matching the keys of the `jform` array. The "CMD" filter will be applied to all the values of the array elements, and they will all have type `string`.
 
-### Option 2
+#### Option 2
 You can define which filter is applied to each of the elements, eg:
+
 ```php
 $value = $input->get('jform', array(), "STRING");
 ```
+
 As in option 1, `$value` will be an associative array with keys matching the keys of the 'jform' array, but in this case the "STRING" filter will be applied to each entry.
 
-### Option 3
+#### Option 3
+
 You can define which elements of the `jform` array you want to capture, specifying the filter to be applied to each:
+
 ```php
 $values = $input->getArray(array(
     'jform' => array(
@@ -158,57 +190,74 @@ $values = $input->getArray(array(
     )
 ));
 ```
+
 This is as in the previous section. 
 
-# GET and POST parameters
+## GET and POST parameters
+
 The `Input` `get` and `post` properties allows you to access HTTP GET and POST parameters:
+
 ```php
 $input->get     // property to retrieve GET parameters
 $input->post    // property to retrieve POST parameters
 ```
+
 You can call the `get()` and `getArray()` methods on these properties to obtain values of parameters, and as above "CMD" is the default filter for `get()` and "STRING" the default filter for `getArray()`.
 
 If your site uses SEF URLs then note that these DON'T include the routing parameters "option", "view", etc which are generated by the Joomla router when it parses the SEF URL. Only true GET and POST parameters are returned. 
 
 For example, to retrieve a GET parameter 'p1' use the following:
+
 ```php
 $value = $input->get->get('p1');
 ```
+
 `$value` will contain the value of GET parameter 'p1', with the value being filtered using the "CMD" filter.
 
 To retrieve a GET parameter 'p1' and use an "INT" filter use (for example) the following:
+
 ```php
 $value = $input->get->get('p1', 0, "int");
 ```
 
 To retrieve all the GET parameters:
+
 ```php
 $value = $input->get->getArray();
 ```
+
 `$value` will contain an associative array of the GET parameters, with the values being filtered using the "STRING" filter.
 
 To retrieve a POST parameter 'p1' use the following:
+
 ```php
 $value = $input->post->get('p1');
 ```
+
 `$value` will contain the value of POST parameter 'p1', with the value being filtered using the "CMD" filter.
 
 To retrieve all the POST parameters:
+
 ```php
 $value = $input->post->getArray();
 ```
+
 `$value` will contain an associative array of the POST parameters, with the values being filtered using the "STRING" filter.
 
 To retrieve the POST parameters of `jform` with no filter being applied to any of the data:
+
 ```php
 $value = $input->post->get("jform", array(), "array");
 ```
+
 This method is used within the Joomla core MVC code to retrieve raw form data. The data array is then passed to the Model `validate` function which handles both the filtering and validation of the data. The filtering is done using the form filters which are described in [how forms work](./forms/how-forms-work.md) using the `bind()` function (note that these filters are different from the `Input` filters we've been discussing in this section) and then validation is performed as described in [server-side validation](./forms/server-side-validation.md).
 
-# Files
+## Files
+
 You may have in your Joomla form an HTML input element with type="file" to enable the user to upload a file to your website. In this case PHP writes the contents of the POST request into a file in its tmp directory, and makes available information about the upload. Joomla provides an easy-to-use interface to access this information. (The information isn't available via GET/POST parameters). 
 
 Suppose you have a form like this:
+
 ```html
 <form action="<?php echo Route::_('index.php?option=com_example&task=file.submit'); ?>" enctype="multipart/form-data" method="post">
 	<input type="file" name="jform1[test][]" />
@@ -216,11 +265,15 @@ Suppose you have a form like this:
 	<input type="submit" value="submit" />
 </form>
 ```
+
 Then you can use:
+
 ```php
 $files = $input->files->get('jform1');
 ```
+
 `$files` then becomes something like: 
+
 ```php
 Array
 (
@@ -247,43 +300,54 @@ Array
 )
 ```
 
-# JSON
+## JSON
+
 When you send the data as a json string in the POST data of an Ajax request, then you can retrieve the data as an associative array by using:
+
 ```php
 $jsonArray = $input->json->get(param_name);
 ```
+
 It won't work for the case where you have multiple POST parameters and one of them is a json string - the whole body has to be a json string. Joomla captures the data from `php://input` and calls `json_decode()` on the data.
 
-Also if you're using this approach then it's recommended to send the security token as one of the GET parameters in the URL.
+Also, if you're using this approach then it's recommended to send the security token as one of the GET parameters in the URL.
 
 For a worked example, look at how Joomla handles the updating of Permissions values in the Global Configuration 
 - in the js file media/system/fields/joomla-field-permissions.js in `sendPermissions()`
 - in the php file  administrator/components/com_config/src/Model/ApplicationModel.php in `storePermissions()`.
 
-# Server data
+## Server data
+
 You can retrieve and sanitise PHP [$_SERVER](https://www.php.net/manual/en/reserved.variables.server.php) data by using:
+
 ```php
 $val = $input->server->get(param_name, default_value, filter);
 ```
 
-# Setting Values
+## Setting Values
+
 The functions `set()` and `def()` allow you to set input parameters and their values.
+
 ```php
 $input->set('p2', "someval");
 ```
+
 sets the value of parameter `p2` to the string "someval" (creating `p2` if it doesn't already exist).
+
 ```php
 $input->def('p2', "someval");
 ```
+
 creates a parameter `p2` and sets its value to the string "someval", but only if `p2` doesn't already exist. If `p2` already exists then `def('p2', "someval");` does nothing. 
 
-# Sample Module Code
+## Sample Module Code
+
 Below is the code for a simple Joomla module which you can install and run to demonstrate retrieval of parameter values. 
 
 In a folder `mod_input` create the following 2 files: 
 
-`mod_input.xml`
-```xml
+
+```xml title="mod_input.xml"
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="module" version="3.1" client="site" method="upgrade">
     <name>Input demo</name>
@@ -294,8 +358,8 @@ In a folder `mod_input` create the following 2 files:
     </files>
 </extension>
 ```
-`mod_input.php`
-```php
+
+```php title="mod_input.php"
 <?php
 defined('_JEXEC') or die('Restricted Access');
 
@@ -318,6 +382,7 @@ else
 	echo "<p>Parameter p1 not specified</p>";
 }
 ```
+
 Zip up the mod_input directory to create `mod_input.zip`.
 
 Within your Joomla administrator go to Install Extensions and via the Upload Package File tab upload this zip file to install this sample module.
@@ -335,22 +400,28 @@ Display a web page on which this module appears. Then add the `p1` parameter to 
 
 You should see the results of retrieving the `p1` parameter, and passing it through different filters. You can experiment by specifying different values for `p1`, applying different filters, and you can use a utility such as [curl](https://curl.se/) to send HTTP POST parameters to confirm it works for those as well. 
 
-# Sample Component Code
+## Sample Component Code
+
 You can also download and use [this sample component code](./forms-fields/_assets/com_sample_form_field.zip) as the basis of experimenting with retrieving POST parameters, files, etc. The src/Controller/PostController.php uses Input to retrieve POST parameters and store them in the session data:
+
 ```php
 // name of array 'jform' must match 'control' => 'jform' line in the model code
 $data  = $this->input->post->get('jform', array(), 'array');
 // store this in the session so that we can display it in DisplayController
 $app->setUserState('com_sample_form_field.post', $data);
 ```
+
 After the redirect back to display the form, the View reads this stored data in src/View/Sample/HtmlView.php:
+
 ```php
 // check if there's any POST data from the previous form submission
 $this->postdata = Factory::getApplication()->getUserState('com_sample_form_field.post', null);
 // and clear it, ready for the next submission
 Factory::getApplication()->setUserState('com_sample_form_field.post', array());
 ```
+
 and then it is displayed in the tmpl/sample/default.php file:
+
 ```php
 ob_start();
 var_dump($this->postdata);
@@ -359,4 +430,5 @@ ob_end_clean();
 ...
 <?php echo '<pre>' . htmlspecialchars($post, ENT_QUOTES) . '</pre>'; ?>
 ```
-By following this pattern you can try out different methods and filters in PostController, then store the result in the session. Then after the redirect you can pick the data out of the session in the View file, and display it in the tmpl default.php file. 
+
+By following this pattern you can try out different methods and filters in PostController, then store the result in the session. Then after the redirect you can pick the data out of the session in the View file, and display it in the tmpl default.php file.

--- a/docs/general-concepts/menus-menuitems.md
+++ b/docs/general-concepts/menus-menuitems.md
@@ -1,7 +1,12 @@
 ---
 title: Menus and Menuitems
 ---
-# Introduction
+
+Menus and Menuitems
+===================
+
+## Introduction
+
 The Joomla Menu and Menuitem classes manage the configuration and display of menus and menu items on the site front end. The Menu is the set of navigation links which you can have as a main menu (e.g. at the top of your site) or as a subsidiary menu (e.g. in the footer). Each of the individual navigation links is a Menuitem. 
 
 Within an overall Menu structure you can have a "submenu". This isn't implemented as a Joomla Menu construct, rather as a set of menu items below a parent menu item. The Joomla menu items are thus implemented in an ordered tree structure, specifically using the [Nested Set model](https://en.wikipedia.org/wiki/Nested_set_model).
@@ -10,20 +15,25 @@ This guide describes how you can use the Joomla API to access the menu and menui
 
 Note that these classes aren't used in the administrator back end.
 
-# Basic Operations
+## Basic Operations
+
 To get the details of all the Menuitems on the site you do:
+
 ```php
 use Joomla\CMS\Factory;
 $app = Factory::getApplication();
 $sitemenu = $app->getMenu();
 ```
+
 If your code is running on the Joomla back end then you should do:
+
 ```php
 use Joomla\CMS\Factory;
 $app = Factory::getApplication();
 $sitemenu = $app->getMenu('site');
 $sitemenu->load();
 ```
+
 The `$sitemenu` structure will then have entries for all the site Menuitems.
 
 (The reason that you don't need to call `load` on the front end is because the Menuitems will most likely have already been loaded by the time your code is run, as they're needed for the site router function. If you a writing a site system plugin which gets called before the router, then you'll need to add the `load` call yourself.)
@@ -31,24 +41,30 @@ The `$sitemenu` structure will then have entries for all the site Menuitems.
 There isn't a Joomla API to enable you to get *just* the set of Menus on the system (as opposed to the set of Menuitems), so if you really do need these then your only recourse is to read the data from the `menu_types` table directly using a SQL query. But you can find (from the Menuitem structure described below) the Menu to which that Menuitem belongs, and find all the Menuitems for a particular Menu. 
 
 To get at the individual menu items we apply a filter to `$sitemenu` using `getItems()` to select the particular Menuitems we're interested in. To obtain an array of all the Menuitems use a blank filter:
+
 ```php
 $menuitems = $sitemenu->getItems(array(), array());
 ```
+
 To obtain an array of all the menu items which are in the "mainmenu" menu use:
+
 ```php
 $mainmenuItems = $sitemenu->getItems('menutype', 'mainmenu');
 ```
+
 The above gives all the menu items within the "mainmenu" menu, including those in submenus. To access just the menu items which are in either the topmost or the first submenu level of the "mainmenu" menu use:
+
 ```php
 $mainmenuItems = $sitemenu->getItems(array('menutype','level'), array('mainmenu',array("1","2")));
 ```
+
 In summary, to filter the specific menu items you want, you pass an array of properties (from the list in the next section) and an array of corresponding values which those properties should have.
 
 Unpublished menu items are not returned. They're not included within the `$sitemenu` structure. 
 
 As mentioned above, there isn't an equivalent method to get the menu items on the administrator back-end, as the Menu and Menuitem classes aren't used. If you wanted to access the menu details you would have to read and interpret the appropriate records from the database. 
 
-# Properties and Parameters
+## Properties and Parameters
 The following are available as public properties of the Menuitem class. Most of these are shown in the first tab ("Details") of the "Menus: Edit Item" form when you're editing a menu item within the back end. Once you have a Menuitem object you can access the properties directly, as shown below. 
 ```php
 $menuitems = $sitemenu->getItems(array(), array());
@@ -99,10 +115,10 @@ Some of these parameters (e.g. those defined in the Link Type tab of the menu it
 
 Other parameters are related to the component which is navigated to via this menu item and contain attributes which related to how the output of that component is displayed on that particular web page. To find these locate the .xml file in the folder where the layout file for that particular page is held. For example, for a page displaying a single contact look in `components/com_contact/tmpl/contact/`. 
 
-# Getting Individual Menu Items
+## Getting Individual Menu Items
 As well as the mechanisms described above for filtering down to the menu item(s) you want, there are some methods available to get directly to certain menu items. 
 
-## Active Menu Item
+### Active Menu Item
 The active menu item of a site web page relates to the menu item which Joomla is using to determine the presentation of that page (e.g. using the Template Style defined for the menu item). To find this use: 
 ```php
 use Joomla\CMS\Factory;
@@ -114,14 +130,14 @@ You can then get the properties and parameters of this menu item as described ab
 
 However, note that there have been unusual cases where the active menu item has not been set (when you get SEF URLs of the form /component/com_xxx).
 
-## Default Menu Item
+### Default Menu Item
 To find the default menu item for a language use for example: 
 ```php
 $menuitem = $sitemenu->getItem($itemid);
 ```
 (When you view the list of menuitems in the administrator back end, then this is the menuitem which has the country's flag set against it.)
 
-## Setting Menu Items
+### Setting Menu Items
 You can set menu item properties and parameters using for example: 
 ```php
 $menuitem->setParams($params)     //set the params values
@@ -130,7 +146,7 @@ $sitemenu->setActive($itemid)     // set the active menu item
 ```
 or by simply assigning different values to the menu item public properties. However these changes are not saved to the database and will last only for the duration of handling the current HTTP request. 
 
-# Sample Module Code
+## Sample Module Code
 Below is the code for a simple Joomla module which you can install and run to demonstrate use of the menu item API functionality. 
 
 In a folder mod_sample_menu create the following 2 files: 

--- a/docs/general-concepts/namespaces/defining-your-namespace.md
+++ b/docs/general-concepts/namespaces/defining-your-namespace.md
@@ -2,12 +2,16 @@
 sidebar_position: 3
 title: Defining your Namespace Prefix
 ---
-# Defining your Namespace Prefix
+Defining your Namespace Prefix
+==============================
+
 ## Components
 When you develop a Joomla extension you define the namespace you want to use in your manifest file, eg for `com_example`:
+
 ```xml
 <namespace path="src">Mycompany\Component\Example</namespace>
 ```
+
 Let's look at the various parts of this:
 
 - Mycompany – you are free to put whatever you like here – it's generally set to indicate the name of the company who developed the extension.
@@ -24,8 +28,11 @@ From this manifest file Joomla will create 2 namespace prefixes:
 - 'Mycompany\Component\Example\Administrator\' will point to administrator/components/com_example/src
 
 (Assuming you have both site and administrator aspects to your component).
+
 ## Modules
+
 You would do a similar thing for modules:
+
 ```xml
 <namespace path="src">Mycompany\Module\Example</namespace>
 <files>
@@ -34,24 +41,28 @@ You would do a similar thing for modules:
 	<folder>tmpl</folder>
 </files>
 ```
-It's not essential to match the "Example" in the namespace to "mod_example" – the name of the module – but you'll probably find it easier to do that. 
+
+It's not essential to match the "Example" in the namespace to "mod_example" 
+– the name of the module – but you'll probably find it easier to do that. 
 
 If this is a site module then Joomla will create the namespace prefix:
-
 'Mycompany\Module\Example\Site\' will point to modules/mod_example/src
 
 If this is an administration module then Joomla will create the namespace prefix:
-
 'Mycompany\Module\Example\Administrator\' will point to administrator/modules/mod_example/src
+
 ## Plugins
+
 For plugins:
+
 ```xml
 <namespace path="src">Mycompany\Plugin\Content\Example</namespace>
-	<files>
-		<filename plugin="example">example.php</filename>
-		<folder>src</folder>
-	</files>
+<files>
+    <filename plugin="example">example.php</filename>
+    <folder>src</folder>
+</files>
 ```
+
 Here there's an extra part to the namespace, which must be set to the plugin type – 'Content' in the example above. 
 
 Once again the 'Example' segment in the namespace doesn't have to match exactly the plugin="example" name of the plugin.
@@ -61,25 +72,43 @@ For the above Joomla would create the namespace prefix:
 'Mycompany\Plugin\Content\Example\' will point to plugins/content/example/src
 
 ## Capitalisation 
-**Be careful to ensure that capitalisation within parts of the fully qualified classname matches capitalisation within the names of directories and files! If you develop on Windows but your target system is linux you may find that your extension works on your development machine but not on your target system. This is because Windows is forgiving if you have wrong capitalisation in your filenames or directory names – it will still open the file for you – but linux isn't.**
+
+**Be careful to ensure that capitalisation within parts of the fully qualified classname matches capitalisation within
+the names of directories and files! If you develop on Windows but your target system is linux you may find that your 
+extension works on your development machine but not on your target system. This is because Windows is forgiving if you 
+have wrong capitalisation in your filenames or directory names – it will still open the file for you – but linux isn't.**
 
 ## Finding your Classes
-Once you have decided upon your namespaces then you can sort out where you class files are going to be located. Joomla components use a fairly flat directory structure under `src`, but you don't stick to that. As long as you adhere to the PSR4 recommendation for matching fully qualified class names to file paths then Joomla will find the source files for your classes. Gone are the days when you had to guess what directory to store your helper file in, and what to name to give the file! 
+
+Once you have decided upon your namespaces then you can sort out where you class files are going to be located. 
+Joomla components use a fairly flat directory structure under `src`, but you don't stick to that. As long as you 
+adhere to the PSR4 recommendation for matching fully qualified class names to file paths then Joomla will find the 
+source files for your classes. Gone are the days when you had to guess what directory to store your helper file in, 
+and what to name to give the file! 
 
 However, there is one case where you need to give Joomla a helping hand - in your form XML files.
 - if you define a custom field then you need to tell Joomla where to find the class which defines that custom field
 - if you define a custom validation rule then you need to tell Joomla where to find the class which defines that rule
 
-As XML files don't have PHP `<namespace>` statements you have to provide the equivalent, and it's easiest to do this by including an `addfieldprefix` or `addruleprefix` attribute within an XML element which encloses where you use them, eg:
+As XML files don't have PHP `<namespace>` statements you have to provide the equivalent, and it's easiest to do this by
+including an `addfieldprefix` or `addruleprefix` attribute within an XML element which encloses where you use them, eg:
+
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <form
     addruleprefix="Mycompany\Component\Example\Administrator\Rule"
     addfieldprefix="Mycompany\Component\Example\Administrator\Field"
-    >
+>
 ```
 
 ## PHP Global namespace
-If you have a `<namespace>` statement in your PHP source file then PHP will by default assume that any classnames you refer to in your code will be under that namespace. So if you use any standard PHP classes such as `Exception`, you will have to precede them with a backslash `\Exception`. The backslash at the start indicates to PHP that this is a fully qualified classname, and as there is just one segment to this FQN it will be found in the global namespace.
 
-Similarly if you use a function, then PHP will try to find that function under your namespace. But unlike classes, if it doesn't find the function under your namespace it will revert back to looking for it in the global namespace. So it's marginally more performant if you tell PHP not to bother looking in your namespace by prefixing the function name with a backslash, eg `\strlen(...)`. You will see this present at times in the Joomla PHP code.
+If you have a `<namespace>` statement in your PHP source file then PHP will by default assume that any classnames you 
+refer to in your code will be under that namespace. So if you use any standard PHP classes such as `Exception`, you 
+will have to precede them with a backslash `\Exception`. The backslash at the start indicates to PHP that this is a 
+fully qualified classname, and as there is just one segment to this FQN it will be found in the global namespace.
+
+Similarly, if you use a function, then PHP will try to find that function under your namespace. But unlike classes, 
+if it doesn't find the function under your namespace it will revert back to looking for it in the global namespace. 
+So it's marginally more performant if you tell PHP not to bother looking in your namespace by prefixing the function 
+name with a backslash, eg `\strlen(...)`. You will see this present at times in the Joomla PHP code.

--- a/docs/general-concepts/namespaces/joomla-namespace-prefixes.md
+++ b/docs/general-concepts/namespaces/joomla-namespace-prefixes.md
@@ -2,11 +2,14 @@
 sidebar_position: 2
 title: Joomla Namespace Prefixes
 ---
-# Joomla Namespace Prefixes
+
+Joomla Namespace Prefixes
+=========================
 
 Joomla holds namespace prefixes and their mapping to the position in the file system for the following:
 
 ## Components
+
 `'Joomla\Component\<Component name>\Administrator\'` points to `administrator/components/com_<component name>/src`
 
 `'Joomla\Component\<Component name>\Site\'` points to `components/com_<component name>/src`
@@ -16,6 +19,7 @@ Joomla holds namespace prefixes and their mapping to the position in the file sy
 eg 'Joomla\Component\Content\Administrator\' points to administrator/components/com_content/src
 
 ## Modules
+
 `'Joomla\Module\<Module name>\Administrator\'` points to `administrator/modules/mod_<module name>/src`
 
 `'Joomla\Module\<Module name>\Site\'` points to `modules/mod_<module name>/src`
@@ -23,11 +27,13 @@ eg 'Joomla\Component\Content\Administrator\' points to administrator/components/
 eg 'Joomla\Module\Login\Site\' points to modules/mod_login/src
 
 ## Plugins
+
 `'Joomla\Plugin\<Plugin type>\<Plugin name>\'` points to `plugins/<plugin type>/<plugin name>/src`
 
 eg 'Joomla\Plugin\Fields\Calendar' points to plugins/fields/calendar/src
 
 ## Library Classes
+
 'Joomla\CMS\' points to libraries/src. Note that these are the classes which are described in the [API docs](https://api.joomla.org/) on the [Joomla CMS](https://api.joomla.org/cms-4/index.html) side. 
 
 'Joomla\SomethingElse\' points to libraries/vendor/somethingelse/src. 
@@ -45,9 +51,11 @@ If a library classname doesn't start with 'Joomla' then it's going to be found i
 If you look in administrator/cache/autoload_psr4.php you'll see all the namespace prefixes for Joomla component, modules and plugins, together with the associated position in the file system (and also the namespace prefixes of any installed extensions).
 
 ## Duplicate class names
+
 Before namespacing was introduced Joomla had a lot of duplicate classnames, eg. for com_example the MVC model code would be in the class ExampleModelExample for both site and administrator, with both classes in the global namespace. This presented an obstacle to sharing code - you couldn't just have your site model class inheriting from your admin model class, for instance.
 
 With Joomla namespacing, the FQNs of the site and administrator model are different, as they're in different namespaces. This makes it very easy to share code between them - you just have to let one model class inherit from the other.
+
 ```php
 <?php
 namespace Mycompany\Component\Example\Site\Model;

--- a/docs/general-concepts/routing/access-component-router-class.md
+++ b/docs/general-concepts/routing/access-component-router-class.md
@@ -2,9 +2,16 @@
 sidebar_position: 4
 title: Accessing the Component Router class
 ---
-# Accessing the Component Router class
-If you're not familiar with Joomla Dependency Injection and Extension classes then you may find it useful to read [Extension and Dispatcher Classes](../extension-and-dispatcher/index.md) and [Dependency Injection](../dependency-injection/index.md) before tackling this section. 
-Since Joomla 4 the preferred way to access the component router class is by using a `RouterFactory` class which is injected as a dependency to the component. This means that in the component's services/provider.php file we have (eg in administrator/components/com_content/services/provider.php):
+
+Accessing the Component Router class
+====================================
+
+If you're not familiar with Joomla Dependency Injection and Extension classes then you may find it useful to 
+read [Extension and Dispatcher Classes](../extension-and-dispatcher/index.md) and [Dependency Injection](../dependency-injection/index.md) before tackling this section. 
+Since Joomla 4 the preferred way to access the component router class is by using a `RouterFactory` class which is 
+injected as a dependency to the component. This means that in the component's services/provider.php file we have 
+(eg in administrator/components/com_content/services/provider.php):
+
 ```php
 use Joomla\CMS\Extension\Service\Provider\RouterFactory;
 ...
@@ -25,12 +32,15 @@ public function register(Container $container)
     );
 }
 ```
+
 Note that here the `RouterFactory` refers to the class ` Joomla\CMS\Extension\Service\Provider\RouterFactory` which is in libraries/src/Extension/Service/Provider/RouterFactory.php. 
 
 The line:
+
 ```php
 $container->registerServiceProvider(new RouterFactory('\\Joomla\\Component\\Content'));
 ```
+
 basically creates an instance of this class, passing in the namespace to use, and calls `register()` on the class instance:
 
 ```php
@@ -53,10 +63,10 @@ public function register(Container $container)
         }
     );
 }
-
 ```
 
-This results in another entry in the Dependency Injection Container (DIC), keyed by `RouterFactoryInterface::class` (which is just a string of the fully qualified name of that class). 
+This results in another entry in the Dependency Injection Container (DIC), keyed by `RouterFactoryInterface::class` 
+(which is just a string of the fully qualified name of that class). 
 
 When the `com_content` component is instantiated Joomla gets it out of the DIC and then these lines are run:
 
@@ -69,7 +79,10 @@ function (Container $container) {
     return $component;
 }
 ```
-The ContentComponent is instantiated - this is the `com_content` Extension class which is in administrator/components/com_content/src/Extension/ContentComponent.php. If you have a look at the code in that file, then you'll see:
+
+The ContentComponent is instantiated - this is the `com_content` Extension class which is in 
+administrator/components/com_content/src/Extension/ContentComponent.php. If you have a look at the code in that file, 
+then you'll see:
 
 ```php
 // outside the class definition
@@ -80,17 +93,21 @@ class ContentComponent extends MVCComponent implements
 // inside the class definition
 use RouterServiceTrait;
 ```
+
 (The PHP `use` statement has [different meanings](https://www.w3schools.com/php/keyword_use.asp) depending upon whether it's used inside or outside a class.) 
-This `RouterServiceTrait` in libraries/src/Component/Router/RouterServiceTrait.php has 2 key functions, which through this `use` statement become methods of the com_content Extension class:
+This `RouterServiceTrait` in libraries/src/Component/Router/RouterServiceTrait.php has 2 key functions, which through 
+this `use` statement become methods of the com_content Extension class:
 1. `setRouterFactory` - this is immediately used in the line:
 
 ```php
 $component->setRouterFactory($container->get(RouterFactoryInterface::class));
 ```
 
-which also gets the `RouterFactoryInterface::class` entry out of the DIC. Referring back to the code in libraries/src/Extension/Service/Provider/RouterFactory.php you can see that getting the entry out of the DIC will result in a `new \Joomla\CMS\Component\Router\RouterFactory` - this now is the genuine RouterFactory class. The ` setRouterFactory` call now stores this instance locally within the com_content Extension as `$this->routerFactory`.
+which also gets the `RouterFactoryInterface::class` entry out of the DIC. Referring back to the code in 
+libraries/src/Extension/Service/Provider/RouterFactory.php you can see that getting the entry out of the DIC will result in a `new \Joomla\CMS\Component\Router\RouterFactory` - this now is the genuine RouterFactory class. The ` setRouterFactory` call now stores this instance locally within the com_content Extension as `$this->routerFactory`.
 
-2. `createRouter` - this function is called when Joomla wants to get the `com_content` component router. As you can see from the `RouterServiceTrait` code, this retrieves the stored `routerFactory` and `calls createRouter` on it:
+2. `createRouter` - this function is called when Joomla wants to get the `com_content` component router. As you 
+3. can see from the `RouterServiceTrait` code, this retrieves the stored `routerFactory` and `calls createRouter` on it:
 
 ```php
 return $this->routerFactory->createRouter($application, $menu);
@@ -98,7 +115,8 @@ return $this->routerFactory->createRouter($application, $menu);
 
 (As you can see, there are 2 `createRouter` functions in different classes here!)
 
-This will result in the `createRouter` function of the genuine `RouterFactory` being called. The code is in libraries/src/Component/Router/RouterFactory.php:
+This will result in the `createRouter` function of the genuine `RouterFactory` being called. The code is in 
+libraries/src/Component/Router/RouterFactory.php:
 
 ```php
 public function createRouter(CMSApplicationInterface $application, AbstractMenu $menu): RouterInterface
@@ -117,14 +135,18 @@ This forms the classname from :
 - the stored namespace (for `com_content` this is `'\\Joomla\\Component\\Content'`, passed in the `registerServiceProvider` call within the com_content services/provider.php file)
 - `$application->getName()` which when we're running on the Joomla site front-end returns "site".
 
-The final class name for `com_content` is \Joomla\Component\Content\Site\Service\Router`, and from the PSR4 namespacing rules this is found in components/com_content/src/Service/Router.php.
+The final class name for `com_content` is \Joomla\Component\Content\Site\Service\Router`, and from the PSR4 
+namespacing rules this is found in components/com_content/src/Service/Router.php.
 
 You should follow this pattern whenever you have a component router for your own component.
 
 ## Your Choice of Component Router
-As described above, Joomla will expect to find your component router in the class `\<Your namespace>\Site\Service\Router` in the file components/com_yourcomponent/src/Service/Router.php, and will expect it to implement the interface `Joomla\CMS\Component\Router\RouterInterface`.
+As described above, Joomla will expect to find your component router in the class `\<Your namespace>\Site\Service\Router`
+in the file components/com_yourcomponent/src/Service/Router.php, and will expect it to implement 
+the interface `Joomla\CMS\Component\Router\RouterInterface`.
 
-At this stage you have the choice of whether to use the traditional router with preprocess(), build() and parse() functions, or to use the `RouterView` option. 
+At this stage you have the choice of whether to use the traditional router with preprocess(), build() and parse() 
+functions, or to use the `RouterView` option. 
 
 If you're using a traditional router then you will have to fill out the skeleton code below:
 
@@ -141,14 +163,20 @@ class Router implements RouterInterface
 }
 ```
 
-If you're using the `RouterView` approach then your class extends Joomla\CMS\Component\Router\RouterView, and this latter class implements `RouterInterface`. You provide the `RouterView` configurations as described in [RouterView Configurations](router-view.md).
+If you're using the `RouterView` approach then your class extends Joomla\CMS\Component\Router\RouterView, and this 
+latter class implements `RouterInterface`. You provide the `RouterView` configurations as 
+described in [RouterView Configurations](router-view.md).
 
 ## Using the Site Router in the Joomla back-end
-There may be occasions where you want to display on the administrator back-end the result of building a SEF URL which will be present on the site front-end. To enable this, Joomla provides the [`link()`](https://api.joomla.org/cms-5/classes/Joomla-CMS-Router-Route.html) method within the `Joomla\CMS\Router\Route` class. It's basically the same as the `Route::_()` function, except that it has an additional parameter "client" at p1, which you would set to "site" to enable a site SEF URL to be built.
+There may be occasions where you want to display on the administrator back-end the result of building a SEF URL which
+will be present on the site front-end. To enable this, Joomla provides the [`link()`](https://api.joomla.org/cms-5/classes/Joomla-CMS-Router-Route.html) method within 
+the `Joomla\CMS\Router\Route` class. It's basically the same as the `Route::_()` function, except that it has an 
+additional parameter "client" at p1, which you would set to "site" to enable a site SEF URL to be built.
 
 However to get this to work in your component you do need to do some extra work.
 
-If you're using a traditional router with preprocess, build and parse functions then the only change you're probably going to have to make is how you obtain the set of site menuitems. When you're running the site application you can use:
+If you're using a traditional router with preprocess, build and parse functions then the only change you're probably
+going to have to make is how you obtain the set of site menuitems. When you're running the site application you can use:
 
 ```php
 $sitemenu = $app->getMenu();
@@ -165,4 +193,9 @@ $sitemenu->load();
 
 as described in [Menus and Menuitems](../menus-menuitems.md#basic-operations). You only need to load them once. 
 
-If your component router uses `RouterView` then you need to ensure that the site menuitems are pre-loaded before you make the `link()` call. The SiteRouter code correctly looks for the site menuitems, even if you're running the functionality from the administrator back-end, but it doesn't perform a `load()`. You may find the routing doesn't work quite as expected; I'm not sure why this is - it may be because the routing algorithm takes into account the current site web page that the user is on (ie the "active" menuitem), which of course is not set if you're calling this functionality from the administrator back-end.
+If your component router uses `RouterView` then you need to ensure that the site menuitems are pre-loaded before
+you make the `link()` call. The SiteRouter code correctly looks for the site menuitems, even if you're running the
+functionality from the administrator back-end, but it doesn't perform a `load()`. You may find the routing doesn't 
+work quite as expected; I'm not sure why this is - it may be because the routing algorithm takes into account the
+current site web page that the user is on (ie the "active" menuitem), which of course is not set if you're calling
+this functionality from the administrator back-end.

--- a/docs/general-concepts/routing/build.md
+++ b/docs/general-concepts/routing/build.md
@@ -2,12 +2,15 @@
 sidebar_position: 2
 title: Building an SEF URL
 ---
-# Building an SEF URL
+
+Building an SEF URL
+===================
+
 The building of an SEF URL is initiated with a call like:
 
 ```php
 use Joomla\CMS\Router\Route;
-...
+…
 $url = Route::_('index.php?option=com_content&view=article&id=21&catid=50&lang=en-GB');
 ```
 
@@ -24,6 +27,7 @@ There are 2 main stages in generating this URL:
 Plus a tidy-up at the end.
 
 ## Preprocess Stage
+
 The preprocess stage falls within the remit of the component router. The Joomla Site Router uses the `option` parameter in the `Route::_()` call to identify the component (`com_content` in this example).  It then looks to call the `preprocess` method of the component router:
 
 ```php
@@ -69,18 +73,23 @@ $segments = array('mountains')
 
 What happens if there aren't any menuitems on the site which relate to the option specified in the `Route::_()` call?
 
-In this case the router will base the SEF URL on the home menuitem (for that language if it's a multilingual site). It will then add on segments which point to the component etc to use. For example, if the component is `com_contact` you could end up with segments something like:
+In this case the router will base the SEF URL on the home menuitem (for that language if it's a multilingual site). 
+It will then add on segments which point to the component etc to use. For example, if the component is `com_contact` 
+you could end up with segments something like:
 
 ```
 /en/component/contact/contact/me?Itemid=1
 ```
 
-This is a bad situation and to be avoided at all costs! The link (if it works at all!) will end up with the home page formatting and modules. 
+This is a bad situation and to be avoided at all costs! The link (if it works at all!) will end up with the home page 
+formatting and modules. 
 
-The situation can easily be avoided by specifying a hidden menuitem which is associated with that component. However, extension developers don't necessarily have control over how administrators build their menu structures. 
+The situation can easily be avoided by specifying a hidden menuitem which is associated with that component. However,
+extension developers don't necessarily have control over how administrators build their menu structures. 
 
 ## Build Stage
-The build stage is largely within the remit of the component router, and the Site Router looks to call the `build` method of the component router:
+The build stage is largely within the remit of the component router, and the Site Router looks to call the `build` 
+method of the component router:
 
 ```php
 public function build(&$query)
@@ -92,7 +101,8 @@ The query parameters are passed as an associative array and should now have the 
 $query = array('Itemid' => '13', 'view' => 'article', 'id' => '21',  catid => '50', ...)
 ```
 
-The job of the component router `build` function is to generate the array of segments for the SEF URL, based on the query parameters passed it. It should return the array of segments and unset any query parameters which are used:
+The job of the component router `build` function is to generate the array of segments for the SEF URL, based on the 
+query parameters passed it. It should return the array of segments and unset any query parameters which are used:
 
 ```php
 $segments = array('50-alps', '21-mont-blanc');
@@ -108,13 +118,23 @@ If you don't unset some of the query parameters then they're added into the URL 
 http://localhost/joom/index.php/en/mountains/50-alps/21-mont-blanc?view=article&id=21
 ```
 
-The component router has the freedom to decide what segments it's going to set. It just has to be able to parse these segments when the URL is clicked by the user. 
+The component router has the freedom to decide what segments it's going to set. It just has to be able to parse these 
+segments when the URL is clicked by the user. 
 
-Traditionally Joomla has set the segment to be of the form `id:alias` of the item, but the `id` part can be removed (leaving just the `alias` as the segment) by setting (for `com_content`) the Global Configuration: Articles / Integration / Routing Remove IDs from URLs option. (Similarly for Contacts). The advantage of the `id:alias` format is that a database lookup isn't required when parsing the incoming URL. If you just use the `alias` format on your component then ensure that there's an index on your `alias` field in the database. 
+Traditionally Joomla has set the segment to be of the form `id:alias` of the item, but the `id` part can be removed 
+(leaving just the `alias` as the segment) by setting (for `com_content`) the Global Configuration: 
+Articles / Integration / Routing Remove IDs from URLs option. (Similarly for Contacts). The advantage of the `id:alias`
+format is that a database lookup isn't required when parsing the incoming URL. If you just use the `alias` format on 
+your component then ensure that there's an index on your `alias` field in the database. 
 
-Generally if the menuitem points to a single item (like a single article, or a single contact) then it can just create a segment which is the `id:alias` (or just alias) of that item. 
+Generally if the menuitem points to a single item (like a single article, or a single contact) then it can just 
+create a segment which is the `id:alias` (or just alias) of that item. 
 
-If the menuitem points to a category list of items then it should provide the category `id:alias`, and it's common to include the parent categories up the category tree. This can be easily found using the CategoryNode `getPath()` method, described in [CategoryNode get Methods](../categories/using-categories-api.md#categorynode-get-methods). (If you're not using ids in the segments then remember that category aliases don't have to be unique throughout a Joomla instance; they just have to be unique across the categories at the same level in the hierarchy. Hence the category path is needed.)
+If the menuitem points to a category list of items then it should provide the category `id:alias`, and it's common 
+to include the parent categories up the category tree. This can be easily found using the CategoryNode `getPath()` 
+method, described in [CategoryNode get Methods](../categories/using-categories-api.md#categorynode-get-methods). (If you're not using ids in the segments then remember that 
+category aliases don't have to be unique throughout a Joomla instance; they just have to be unique across the 
+categories at the same level in the hierarchy. Hence the category path is needed.)
 
 In our example we've assumed that the menuitem relates to a category list, and we provide as segments:
 - the `id-alias` ('50-alps') of the item's category (which we've assumed is at the top level of the category tree)
@@ -127,4 +147,7 @@ Including the 'mountains' segment which was found in the `preprocess` function, 
 ```
 
 ## Remainder of URL
-By this stage all the hard work of generating the SEF URL has been done. All that remains is to add the language segment (again done by the Language Filter plugin on a multilingual site), and the domain and entry point (index.php) if required.
+
+By this stage all the hard work of generating the SEF URL has been done. All that remains is to add the language 
+segment (again done by the Language Filter plugin on a multilingual site), and the domain and entry 
+point (index.php) if required.

--- a/docs/general-concepts/routing/index.md
+++ b/docs/general-concepts/routing/index.md
@@ -1,7 +1,13 @@
 ---
 title: Routing
 ---
-# Introduction
+
+Routing
+=======
+
+## Introduction
+
+
 In the context of a web application, routing involves analysing an incoming URL to determine which application constituent parts need to be involved to handle the request. Sometimes this is fairly straightforward, but in a Joomla site the support of Search Engine Friendly (SEF) URLs make this job particularly challenging. It is the responsibility of the Joomla Site Router to convert between SEF URLs and the internal URL format (which identifies those constituent parts).
 
 When people access web pages on your site you want to have URLs which naturally reflect the content that is being shown, like `mysite.org/articles/latest-news`.

--- a/docs/general-concepts/routing/parse.md
+++ b/docs/general-concepts/routing/parse.md
@@ -2,7 +2,9 @@
 sidebar_position: 1
 title: Parsing an SEF URL
 ---
-# Parsing an SEF URL
+
+Parsing an SEF URL
+==================
 
 Using the following SEF URL let's consider what the parse function involves: 
 

--- a/docs/general-concepts/routing/router-view.md
+++ b/docs/general-concepts/routing/router-view.md
@@ -2,7 +2,10 @@
 sidebar_position: 3
 title: RouterView
 ---
-# RouterView
+
+RouterView
+==========
+
 Writing the router preprocess, parse and build functions for your component can be a challenging task. If your component broadly follows the example of `com_content` in having items which are grouped by categories then using RouterView configurations can save you a lot of work.
 
 On the other hand, if you find it doesn't work then it's practically impossible to debug to find where things have gone wrong, and you're better just using the preprocess, parse and build functions.

--- a/docs/general-concepts/webservices.md
+++ b/docs/general-concepts/webservices.md
@@ -1,5 +1,6 @@
 Web Services
 ============
+
 Description of the webservices concept
 
 - Web Services are used to make systems COMMUNICATE each other by using the HTTP protocol and nowadays over TLS (Transport Layer Security).
@@ -7,18 +8,18 @@ Description of the webservices concept
 - Simply put, Web Services are like doors and windows in a house, they are INPUTS and OUTPUTS to the OUTSIDE world.
 - In the context on Joomla! as a system, Joomla Webservices API allows Joomla! to INTERACT WITH, EXTERNAL DATASOURCES. Like webapps, mobile,etc...
 
-# Communicate with the Joomla 4.x Web Services API
+## Communicate with the Joomla 4.x Web Services API
 The communication with Joomla's Web Services API takes place via specified endpoints.
 
 - Joomla's core endpoints: https://docs.joomla.org/J4.x:Joomla_Core_APIs
 - A collection of Joomla endpoints to use in Postman: https://github.com/alexandreelise/j4x-api-collection
 
-## Using the Joomla framework
+### Using the Joomla framework
 
 More often than not, when using the Joomla framework, under the hood it still uses cURL or php streams. Most of the cURL is available with your web hosting provider. Otherwise check phpinfo();
 You should be able to follow along because the examples using the Joomla framework will mimic those with cURL.
 
-### Define some variables
+#### Define some variables
 First we define some variables that we use in all our cURL requests:
 - the URL of your Joomla 4.x website and
 - the Joomla's API Token of a Super User account or an account which has at least core.login.api permission and core.login.site to be able to see change current logged-in user's token.
@@ -41,7 +42,8 @@ $token = '';
 ```
 
 
-### POST - Create an Article in the Category "Uncategorized" (Category ID = 2)
+#### POST - Create an Article in the Category "Uncategorized" (Category ID = 2)
+
 ```php
 $categoryId = 2; // Joomla's default "Uncategorized" Category
 
@@ -79,7 +81,8 @@ echo $response->body;
 
 ```
 
-### GET - Retrieve all articles from the "Uncategorized" Category
+#### GET - Retrieve all articles from the "Uncategorized" Category
+
 ```php
 $categoryId = 2; // Joomla's default "Uncategorized" Category
 
@@ -107,7 +110,8 @@ echo $response->body;
 
 ```
 
-### GET - Retrieve one specific Article
+#### GET - Retrieve one specific Article
+
 ```php
 $articleId = 1; // The Article ID of a specific Article
 
@@ -135,7 +139,8 @@ echo $response->body;
 
 ```
 
-### PATCH - Modify a specific Article
+#### PATCH - Modify a specific Article
+
 ```php
 $articleId = 1; // The Article ID of a specific Article
 
@@ -170,7 +175,8 @@ echo $response->code;
 
 ```
 
-### DELETE - Remove a specific Article
+#### DELETE - Remove a specific Article
+
 ```php
 $articleId = 1; // The Article ID of a specific Article
 
@@ -195,21 +201,19 @@ $response = $http->request('DELETE', $uri, $dataString, $headers, $timeout);
 
 // show response status code
 echo $response->code;
-
 ```
 
 
-## Using the PHP cURL Functions
+### Using the PHP cURL Functions
+
 The cURL functions needs to be available and enabled in your PHP configuration, check phpinfo();
 
-### Define some variables
+#### Define some variables
+
 First we define some variables that we use in all our cURL requests:
 
 - the URL of your Joomla 4.x website and
 - the Joomla's API Token of a Super User account or an account which has at least core.login.api permission and core.login.site to be able to see change current logged-in user's token.
-
-
-
 
 ```php
 // Before passing the HTTP METHOD to CURL
@@ -221,10 +225,10 @@ $url   = 'https://example.org/api/index.php/v1';
 // We should not use environment variables to store secrets.
 // Here is why: https://www.trendmicro.com/en_us/research/22/h/analyzing-hidden-danger-of-environment-variables-for-keeping-secrets.html
 $token = '';
-
 ```
 
-### POST - Create an Article in the Category "Uncategorized" (Category ID = 2)
+#### POST - Create an Article in the Category "Uncategorized" (Category ID = 2)
+
 ```php
 $categoryId = 2; // Joomla's default "Uncategorized" Category
 
@@ -268,7 +272,8 @@ curl_close($curl);
 echo $response;
 ```
 
-### GET - Retrieve all articles from the "Uncategorized" Category
+#### GET - Retrieve all articles from the "Uncategorized" Category
+
 ```php
 $categoryId = 2; // Joomla's default "Uncategorized" Category
 
@@ -298,7 +303,8 @@ curl_close($curl);
 echo $response;
 ```
 
-### GET - Retrieve one specific Article
+#### GET - Retrieve one specific Article
+
 ```php
 $articleId = 1; // The Article ID of a specific Article
 
@@ -327,7 +333,8 @@ curl_close($curl);
 echo $response;
 ```
 
-### PATCH - Modify a specific Article
+#### PATCH - Modify a specific Article
+
 ```php
 $articleId = 1; // The Article ID of a specific Article
 
@@ -368,7 +375,8 @@ curl_close($curl);
 echo $response;
 ```
 
-### DELETE - Remove a specific Article
+#### DELETE - Remove a specific Article
+
 ```php
 $articleId = 1; // The Article ID of a specific Article
 

--- a/docs/get-started/git/index.md
+++ b/docs/get-started/git/index.md
@@ -2,7 +2,8 @@
 sidebar_position: 3
 ---
 
-# Git
+Git
+===
 
 From Wikipedia: [Git](https://en.wikipedia.org/wiki/Git) is free and open source software for distributed version control: tracking changes in any set of files, usually used for coordinating work among programmers collaboratively developing source code during software development. Its goals include speed, data integrity, and support for distributed, non-linear workflows (thousands of parallel branches running on different systems).
 

--- a/docs/get-started/ide/eclipse.md
+++ b/docs/get-started/ide/eclipse.md
@@ -2,7 +2,9 @@
 title: Eclipse
 sidebar_position: 3
 ---
-# Eclipse
+Eclipse
+=======
+
 This section explains how to install Eclipse together with Xdebug for developing with Joomla. As these products are both open source projects this option is free of charge. There are videos available online which show you how to install these products, but some of the key steps are explained below. It's assumed you have got an environment such as [WAMP](https://www.wampserver.com/) or [XAMPP](https://www.apachefriends.org/) running on your local machine, and that you're familiar with how to use it.
 
 ## Install Xdebug

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,8 @@ sidebar_position: 0
 title: Introduction
 ---
 
-# Welcome to the Joomla! Programmers Documentation for Joomla 5.0
+Welcome to the Joomla! Programmers Documentation for Joomla 5.2
+===============================================================
 
 This documentation hold information for developers of templates, modules, plugins, components, libraries.
 In Joomla! context all kind of this software are called extension. People often split extensions in to 2 categories.

--- a/docs/testing/automated/concepts.md
+++ b/docs/testing/automated/concepts.md
@@ -3,11 +3,11 @@ sidebar_position: 1
 ---
 
 Concepts
-=============
+========
 
 For Joomla! we are using different strategies to test the application.
 
-# System Testing versus Unit Testing
+## System Testing versus Unit Testing
 
 System Testing and Unit Testing are complementary test strategies. In Joomla!, Unit Testing is mainly used to test the framework classes (for example, the classes in libraries/joomla). Unit tests test that an individual method (also known as function) in a class does what it is supposed to do. For example, a unit test is used to test that the methods in the JString class work as expected. Unit testing provides confidence that the framework classes work as expected and allows you to refactor these classes (improve the code without changing the functionality) and still have confidence that they still work correctly.
 

--- a/docs/testing/index.md
+++ b/docs/testing/index.md
@@ -3,15 +3,15 @@ sidebar_position: 10
 ---
 
 Testing
-=============
+=======
 
-# Overview
+## Overview
 
 Testing Software is an important part of software development. For Joomla! we have different levels of testing:
 
-## Automated Testing
+### Automated Testing
 
 For the automated testing we are using a continuous integration (CI) server drone. Any change that is made runs a series of tests on the CI system. We test if the code style for PHP, CSS and javascript is correct, run unit test for the supported PHP versions and run end to end tests. All this not only runs on different PHP version we are also testing different database version. At the end of the test we create an installable package with the changes included to support our manually testing. If something fails we save information about the reason.
 
-## Manually Testing
+### Manually Testing
 While automated testing is more focused on making sure that a change doesn't break existing functionality, is manually testing focused on the change itself. Always tow people have to confirm that a change does for what is made. This can be a bugfix or new functionality.

--- a/docs/user-interface-text/action_or_description.md
+++ b/docs/user-interface-text/action_or_description.md
@@ -2,7 +2,9 @@
 sidebar_position: 2
 ---
 
-# Action or Description
+Action or Description
+=====================
+
 ## Archive / Unarchive Vs Archived / Unarchived
 * Archive is an action so it is used on buttons
 * Unarchive is an action so it is used on buttons

--- a/docs/user-interface-text/capitalisation.md
+++ b/docs/user-interface-text/capitalisation.md
@@ -2,7 +2,9 @@
 sidebar_position: 3
 ---
 
-# Capitalisation
+Capitalisation
+==============
+
 DON'T USE BLOCK CAPITALS FOR LARGE AMOUNTS OF TEXT AS IT'S QUITE HARD TO READ.
 
 Sentence case is preferable but use capitalisation for:

--- a/docs/user-interface-text/index.md
+++ b/docs/user-interface-text/index.md
@@ -2,7 +2,9 @@
 sidebar_position: 999
 ---
 
-# User Interface Text Guidelines
+User Interface Text Guidelines
+==============================
+
 The official language of Joomla is en-GB and this guide is intended to assist anyone writing language strings in en-GB (British English). This guide should not be translated but may help serve as a starting point for Translation Teams to localise and produce their own guide.
 
 ## Purpose

--- a/docs/user-interface-text/joomla_name_usage.md
+++ b/docs/user-interface-text/joomla_name_usage.md
@@ -2,7 +2,9 @@
 sidebar_position: 4
 ---
 
-# Use of the Joomla Name
+Use of the Joomla Name
+======================
+
 "Joomla!" is our name, and as such it deserves everyone's best efforts to protect it.  It defines our brand for both our software and our community.  It signifies our reputation for excellence.  We have specific guidelines for when and how to properly use our trademarks in public-facing content such as marketing materials and Joomla.org web pages.  Those guidelines are excessive within a controlled user-facing environment like the Joomla backend.
 
 ## "Joomla!" should always be capitalised ... ALWAYS

--- a/docs/user-interface-text/punctuation.md
+++ b/docs/user-interface-text/punctuation.md
@@ -2,7 +2,9 @@
 sidebar_position: 5
 ---
 
-# Punctuation
+Punctuation
+===========
+
 ## Ampersand
 Unless in a title or referring to a title use 'and' rather than an '&', unless it's part of a trademark. Where it is used then it should be `&amp;` and not `&`
 

--- a/docs/user-interface-text/references.md
+++ b/docs/user-interface-text/references.md
@@ -2,7 +2,8 @@
 sidebar_position: 99
 ---
 
-# External References
+External References
+===================
 
 ## Main en-GB Sources
 * [gov.uk](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style) [(licence)](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/)

--- a/docs/user-interface-text/words2watch.md
+++ b/docs/user-interface-text/words2watch.md
@@ -2,7 +2,9 @@
 sidebar_position: 6
 ---
 
-# Words to Watch
+Words to Watch
+==============
+
 **This is a 'living document' that can be updated as needed over time.**
 
 Words to Watch (W2W) are words commonly misspelled or which may have variations that depend on the Joomla! style guide choices.

--- a/docs/web-services-api/index.md
+++ b/docs/web-services-api/index.md
@@ -1,4 +1,5 @@
-# Web Services API
+Web Services API
+================
 
 This is the content for tutorials how to work with the webservices API of Joomla.
 :::caution TODO

--- a/docs/web-services-api/json-response-format/index.md
+++ b/docs/web-services-api/json-response-format/index.md
@@ -1,4 +1,5 @@
-# JSON Response Format
+JSON Response Format
+====================
 
 Joomla by default will return a [JSON API](https://jsonapi.org/) Responses when requested with an Accept: application/json header as well as with the specific JSON API header. Although the Core of Joomla will not support additional content types, **support the ability that developers add additional content types that can be responded**.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manual",
-  "version": "5.0",
+  "version": "5.1",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/versioned_docs/version-5.1/index.md
+++ b/versioned_docs/version-5.1/index.md
@@ -3,7 +3,8 @@ sidebar_position: 0
 title: Introduction
 ---
 
-# Welcome to the Joomla! Programmers Documentation for Joomla 5.0
+Welcome to the Joomla! Programmers Documentation for Joomla 5.1
+===============================================================
 
 This documentation hold information for developers of templates, modules, plugins, components, libraries.
 In Joomla! context all kind of this software are called extension. People often split extensions in to 2 categories.


### PR DESCRIPTION
Reformat the code to be more accessible and a bit more seo friends.

Also did some reformating of other parts to but more space into the markdown files.

We will not use any `#` for title tag any more only `====` this allows easier to find wrong usages of h1 headlines.

Also adding a blank line between command blocks like headline or codeblocks makes the code more readable.

Lines should not be too long, maybe around 160 characters