### PR TITLE
[5.1] Joomla 51 has been released - remove notice

### DIFF
--- a/migrations/50-51/new-deprecations.md
+++ b/migrations/50-51/new-deprecations.md
@@ -4,10 +4,6 @@ sidebar_position: 2
 
 # New deprecations
 
-:::tip[Developer Note]
-  Since this version of Joomla has not been released yet, this page can change anytime.
-:::
-
 All the new deprecations that should be aware of and what you should now be using instead.
 
 # Language strings

--- a/migrations/50-51/new-features.md
+++ b/migrations/50-51/new-features.md
@@ -4,10 +4,6 @@ sidebar_position: 1
 
 # New features
 
-:::tip[Developer Note]
-  Since this version of Joomla has not been released yet, this page can change anytime.
-:::
-
 All the new features that have been added to this version.
 Any changes in best practice.
 

--- a/migrations/50-51/removed-backward-incompatibility.md
+++ b/migrations/50-51/removed-backward-incompatibility.md
@@ -4,9 +4,5 @@ sidebar_position: 3
 
 # Removed and backward incompatibility
 
-:::tip[Developer Note]
-  Since this version of Joomla has not been released yet, this page can change anytime.
-:::
-
 All the deprecated features than have now been removed and any backward incompatibilities.
 There should be an explanation of how to mitigate the removals / changes.


### PR DESCRIPTION
Joomla 5.1 has been released, so the developer note at the top is no longer necessary:

DEVELOPER NOTE
Since this version of Joomla has not been released yet, this page can change anytime.