### PR TITLE
Fix typo index.md

### DIFF
--- a/versioned_docs/version-5.1/index.md
+++ b/versioned_docs/version-5.1/index.md
@@ -17,4 +17,4 @@ But basically it shouldn't matter if the extension is provided by Joomla or by a
 This manual should help any kind of developer, if you are a template creator or just want to write the next
 Joomla shop system. Everything you need to understand Joomla development should be found here.
 If something is missing (this chance is really since we getting started this new documentation) please don't
-hasitate to contribute with a [github pull request](https://github.com/joomla/Manual/) to improve the manual for all of us.
+hesitate to contribute with a [github pull request](https://github.com/joomla/Manual/) to improve the manual for all of us.


### PR DESCRIPTION
### **User description**
typo hasitate -> hesitate


___

### **PR Type**
Bug fix


___

### **Description**
- Corrected a typo in the `versioned_docs/version-5.1/index.md` file, changing 'hasitate' to 'hesitate'.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.md</strong><dd><code>Fix typo in documentation index file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
versioned_docs/version-5.1/index.md

- Corrected a typo from 'hasitate' to 'hesitate'.



</details>
    

  </td>
  <td><a href="https://github.com/joomla/Manual/pull/271/files#diff-24e9b95bb390f0bfd348f51a9442c9968a75e3d82b38944b94006abf34f09dcd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

