### PR TITLE
[6.0] [BC Break] Web cron scheduler does not tigger tasks at all #43490

### DIFF
--- a/migrations/54-60/removed-backward-incompatibility.md
+++ b/migrations/54-60/removed-backward-incompatibility.md
@@ -26,7 +26,7 @@ There should be an explanation of how to mitigate the removals / changes.
 ### Web cron scheduler `id` parameter has been changed to `taskid` 
 
 - PR: https://github.com/joomla/joomla-cms/pull/43490
-- Description: The Web cron scheduler `id` parameter has been changed to `taskid` all links need to be updated to the new ID. As a fallback, as when the taskid is not set the tasks will be queued and triggered.
+The Web cron scheduler `id` parameter has been changed to `taskid`. All references to the old `id` parameter in URLs or API calls should be updated to `taskid`. For example, change `https://example.com/cron?id=123` to `https://example.com/cron?taskid=123`. Ensure all documentation and scripts are updated accordingly.
 
 ```php
 // Old

--- a/migrations/54-60/removed-backward-incompatibility.md
+++ b/migrations/54-60/removed-backward-incompatibility.md
@@ -22,3 +22,16 @@ There should be an explanation of how to mitigate the removals / changes.
 
 - PR: https://github.com/joomla/joomla-cms/pull/42884
 - Description: The class `\Joomla\CMS\Application\BaseApplication` and `\Joomla\CMS\Application\CliApplication` respective CLI input classes have been removed. The CMS core code has been switched to use the Application package of the Joomla Framework. Any reference to these classes should be replaced with the namespace `\Joomla\Application`. Cli apps should be replaced by console plugins.
+
+### Web cron scheduler `id` parameter has been changed to `taskid` 
+
+- PR: https://github.com/joomla/joomla-cms/pull/43490
+- Description: The Web cron scheduler `id` parameter has been changed to `taskid` all links need to be updated to the new ID. As a fallback, as when the taskid is not set the tasks will be queued and triggered.
+
+```php
+// Old
+$id = (int) $this->getApplication()->getInput()->getInt('id', 0);
+
+// New
+$taskId = (int) $this->getApplication()->getInput()->getInt('taskid', 0);
+```


### PR DESCRIPTION
### **User description**
See: https://github.com/joomla/joomla-cms/pull/43490


___

### **PR Type**
documentation


___

### **Description**
- Added documentation for the Web cron scheduler parameter change from `id` to `taskid`.
- Included a code example to illustrate the change.
- Provided a description and mitigation steps for updating links to the new parameter.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>removed-backward-incompatibility.md</strong><dd><code>Documented Web cron scheduler parameter change</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/54-60/removed-backward-incompatibility.md

<li>Added a section about the Web cron scheduler <code>id</code> parameter change to <br><code>taskid</code>.<br> <li> Provided a code example for updating the parameter.<br> <li> Included a description and mitigation steps for the change.<br>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/286/files#diff-1b9f27ae2f64c35bc2cdba1c2988613e48b706934385a2e51f36e0e1bd2d23b2">+13/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

