### PR TITLE
Media field: allow to select folders

### DIFF
--- a/docs/general-concepts/forms-fields/standard-fields/media.md
+++ b/docs/general-concepts/forms-fields/standard-fields/media.md
@@ -13,7 +13,11 @@ The **media** form field type provides modal access to the media manager for the
 -  **preview** (optional) shows or hides the preview of the currently chosen image. ("true": Show always, "tooltip": Show as tooltip, "false": Show never). Default is "tooltip".
 - **preview_width** (optional) sets the max-width of preview image (default: "200").
 - **preview_height** (optional) sets the max-height of preview image (default: "200").
-- **types** (optional) is a comma-separated list of file types (`images`, `audios`, `videos`, `documents`, `directories`). Default is `images`. This list decides which of the allowed file extensions from Media Manager configuration are used. E.g. `images,documents` means only files with an allowed images extension or an allowed documents extension are available for selection (since Joomla 4.0.0). When the type `directories` is used then the field will allow to select a directory, this can be useful in extension parameters, to select upload destination etc (since Joomla 5.2).
+- **types** (optional) is a comma-separated list of file types (`images`, `audios`, `videos`, `documents`, `directories`). 
+Default is `images`. This list decides which of the allowed file extensions from Media Manager configuration are used. 
+For example, `images,documents` means only files with an allowed images extension or an allowed documents extension are available for selection. 
+When the type `directories` is used then the field will allow selection of a directory; 
+this can be useful in setting extension parameters, to define an upload destination for example.
 
 Implemented by: libraries/src/Form/Field/MediaField.php
 

--- a/docs/general-concepts/forms-fields/standard-fields/media.md
+++ b/docs/general-concepts/forms-fields/standard-fields/media.md
@@ -13,7 +13,7 @@ The **media** form field type provides modal access to the media manager for the
 -  **preview** (optional) shows or hides the preview of the currently chosen image. ("true": Show always, "tooltip": Show as tooltip, "false": Show never). Default is "tooltip".
 - **preview_width** (optional) sets the max-width of preview image (default: "200").
 - **preview_height** (optional) sets the max-height of preview image (default: "200").
-- **types** (optional) is a comma-separated list of file types (`images`, `audios`, `videos`, `documents`, `directories`). Default is `images`. This list decides which of the allowed file extensions from Media Manager configuration are used. E.g. `images,documents` means only files with an allowed images extension or an allowed documents extension are available for selection (since Joomla 4.0.0). When the type `directories` is used then the field will allow to select a directory, this can be usefull in extension parameters, to select upload destination etc (since Joomla 5.2).
+- **types** (optional) is a comma-separated list of file types (`images`, `audios`, `videos`, `documents`, `directories`). Default is `images`. This list decides which of the allowed file extensions from Media Manager configuration are used. E.g. `images,documents` means only files with an allowed images extension or an allowed documents extension are available for selection (since Joomla 4.0.0). When the type `directories` is used then the field will allow to select a directory, this can be useful in extension parameters, to select upload destination etc (since Joomla 5.2).
 
 Implemented by: libraries/src/Form/Field/MediaField.php
 

--- a/docs/general-concepts/forms-fields/standard-fields/media.md
+++ b/docs/general-concepts/forms-fields/standard-fields/media.md
@@ -13,7 +13,7 @@ The **media** form field type provides modal access to the media manager for the
 -  **preview** (optional) shows or hides the preview of the currently chosen image. ("true": Show always, "tooltip": Show as tooltip, "false": Show never). Default is "tooltip".
 - **preview_width** (optional) sets the max-width of preview image (default: "200").
 - **preview_height** (optional) sets the max-height of preview image (default: "200").
-- **types** (optional) is a comma-separated list of file types ("images", "audios", "videos" and "documents"). Default is "images". This list decides which of the allowed file extensions from Media Manager configuration are used. E.g. "images,documents" means only files with an allowed images extension or an allowed documents extension are available for selection. (since Joomla 4.0.0)
+- **types** (optional) is a comma-separated list of file types (`images`, `audios`, `videos`, `documents`, `directories`). Default is `images`. This list decides which of the allowed file extensions from Media Manager configuration are used. E.g. `images,documents` means only files with an allowed images extension or an allowed documents extension are available for selection (since Joomla 4.0.0). When the type `directories` is used then the field will allow to select a directory, this can be usefull in extension parameters, to select upload destination etc (since Joomla 5.2).
 
 Implemented by: libraries/src/Form/Field/MediaField.php
 

--- a/migrations/51-52/new-features.md
+++ b/migrations/51-52/new-features.md
@@ -18,6 +18,6 @@ displaying the number of items available after applying filters for easier item 
 PR: [43575](https://github.com/joomla/joomla-cms/pull/43575)
 
 #### Media field: allow to select folders
-It is now possible to select directories usign the Media field.
+It is now possible to select directories using the Media field.
 
 PR: https://github.com/joomla/joomla-cms/pull/43579

--- a/migrations/51-52/new-features.md
+++ b/migrations/51-52/new-features.md
@@ -16,3 +16,8 @@ This new feature adds a "total" counter at the bottom near the pagination in Joo
 displaying the number of items available after applying filters for easier item management.
 
 PR: [43575](https://github.com/joomla/joomla-cms/pull/43575)
+
+#### Media field: allow to select folders
+It is now possible to select directories usign the Media field.
+
+PR: https://github.com/joomla/joomla-cms/pull/43579


### PR DESCRIPTION
### **User description**
PR for:
- https://github.com/joomla/joomla-cms/pull/43579


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Updated the media field documentation to include the new `directories` type, allowing users to select directories.
- Documented the new feature in the migration guide, highlighting the ability to select directories using the media field.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>media.md</strong><dd><code>Update media field documentation to include directory selection</code></dd></summary>
<hr>

docs/general-concepts/forms-fields/standard-fields/media.md

<li>Added <code>directories</code> to the list of file types for the media field.<br> <li> Explained the usage of <code>directories</code> type for selecting directories.<br>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/288/files#diff-969eba15ef9fe8db5efa41fdb65857a79791b0259ccf631e1deed3f1397ec072">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>new-features.md</strong><dd><code>Document new feature for media field directory selection</code>&nbsp; </dd></summary>
<hr>

migrations/51-52/new-features.md

<li>Added a new feature description for allowing directory selection in <br>the media field.<br> <li> Included a reference to the relevant PR.<br>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/288/files#diff-c9cf512d274255590a3c0d7048db6c59ebf526c4d91b6e3fcf073745efab7746">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

