### PR TITLE
Auto-start and events information

### DIFF
--- a/docs/general-concepts/guided-tours.md
+++ b/docs/general-concepts/guided-tours.md
@@ -83,9 +83,9 @@ Starting with Joomla 5.2, you can set tours to auto start. Those tours will run 
 ### Event dispatchers
 
 Once a user cancels, opts-out or completes a tour, events are triggered, allowing developers to act according to user actions. One may want to send a message to a user after completion of a tour in order to propose another one, for instance.
-Those events are: 
-- onBeforeTourSaveUserState: triggered before saving the auto-start tour user state (used to record states in the User Action Logs),
-- onAfterTourSaveUserState: triggered after saving the auto-start tour user state.
+Those events are triggered at different stages:
+- onBeforeTourSaveUserState: before saving the auto-start tour user state (used to record states in the User Action Logs),
+- onAfterTourSaveUserState: after saving the auto-start tour user state.
 
 You can find those events in the AjaxController class.
 

--- a/docs/general-concepts/guided-tours.md
+++ b/docs/general-concepts/guided-tours.md
@@ -75,6 +75,22 @@ Note that the Guided Tour component knows how to differentiate category tours fo
 There is no available tour when editing a specific module, plugin or template. That is where launching a tour from anywhere can become handy.
 
 
+### Auto start
+
+Starting with Joomla 5.2, you can set tours to auto start. Those tours will run automatically once a user enters the context of the tour. Once a tour auto starts, the user can hide the tour forever (although the tour can still be run manually), and a cancellation will delay the tour for a later run. Once a specific time has passed (the delay setting can be found in the Global Configuration of the Guided Tours - it defaults to 1 hour), the tour will run again automatically, once in context.
+
+
+### Event dispatchers
+
+Once a user cancels, opts-out or completes a tour, events are triggered, allowing developers to act according to user actions. One may want to send a message to a user after completion of a tour in order to propose another one, for instance.
+Those events are: 
+- onBeforeTourRunSaveState: triggered before saving the auto-start tour user state and recording user action logs
+- onTourRunSaveState: triggered before saving the auto-start tour user state, used to record user actions into the logs
+- onAfterTourRunSaveState: triggered after saving the auto-start tour user state and recording user action logs
+
+You can find those events in the AjaxController. 
+
+
 ## Launching a tour from any location
 
 Launching a tour from a different location than the Guided Tours module is as easy as adding the attribute `data-gt-uid` with the identifier of the tour.

--- a/docs/general-concepts/guided-tours.md
+++ b/docs/general-concepts/guided-tours.md
@@ -87,7 +87,14 @@ Those events are:
 - onBeforeTourSaveUserState: triggered before saving the auto-start tour user state (used to record states in the User Action Logs),
 - onAfterTourSaveUserState: triggered after saving the auto-start tour user state.
 
-You can find those events in the AjaxController class. 
+You can find those events in the AjaxController class.
+
+
+### Adding images to the content
+
+Use the editor to include images inside the content descriptions. Images are located in the media folder, ```/images``` by default.
+However, expecially when creating a tour for a third party extension, you may want to include images located in the media folder of the extension.
+In this case, the image path must start with ```media/...```.
 
 
 ## Launching a tour from any location

--- a/docs/general-concepts/guided-tours.md
+++ b/docs/general-concepts/guided-tours.md
@@ -84,11 +84,10 @@ Starting with Joomla 5.2, you can set tours to auto start. Those tours will run 
 
 Once a user cancels, opts-out or completes a tour, events are triggered, allowing developers to act according to user actions. One may want to send a message to a user after completion of a tour in order to propose another one, for instance.
 Those events are: 
-- onBeforeTourRunSaveState: triggered before saving the auto-start tour user state and recording user action logs
-- onTourRunSaveState: triggered before saving the auto-start tour user state, used to record user actions into the logs
-- onAfterTourRunSaveState: triggered after saving the auto-start tour user state and recording user action logs
+- onBeforeTourSaveUserState: triggered before saving the auto-start tour user state (used to record states in the User Action Logs),
+- onAfterTourSaveUserState: triggered after saving the auto-start tour user state.
 
-You can find those events in the AjaxController. 
+You can find those events in the AjaxController class. 
 
 
 ## Launching a tour from any location


### PR DESCRIPTION
### **PR Type**
Documentation
for PR #43814

___

### **Description**
- Added documentation for the auto-start feature in guided tours, explaining how tours can be set to run automatically and user options for hiding or delaying tours.
- Introduced a new section on event dispatchers, detailing the events triggered when a user cancels, opts-out, or completes a tour.
- Listed specific events (`onBeforeTourRunSaveState`, `onTourRunSaveState`, `onAfterTourRunSaveState`) and their purposes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>guided-tours.md</strong><dd><code>Document auto-start and event dispatchers for guided tours</code></dd></summary>
<hr>

docs/general-concepts/guided-tours.md

<li>Added section on auto-start functionality for guided tours.<br> <li> Introduced event dispatchers for tour actions.<br> <li> Detailed specific events triggered by user actions on tours.<br>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/290/files#diff-17a0ef1a44cd797398ccaf51bef63b57bf98dd5c9777f198075f09030e31928a">+16/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

