### PR TITLE
Doku change for GMT to UTC change

### DIFF
--- a/migrations/54-60/removed-backward-incompatibility.md
+++ b/migrations/54-60/removed-backward-incompatibility.md
@@ -22,3 +22,8 @@ There should be an explanation of how to mitigate the removals / changes.
 
 - PR: https://github.com/joomla/joomla-cms/pull/42884
 - Description: The class `\Joomla\CMS\Application\BaseApplication` and `\Joomla\CMS\Application\CliApplication` respective CLI input classes have been removed. The CMS core code has been switched to use the Application package of the Joomla Framework. Any reference to these classes should be replaced with the namespace `\Joomla\Application`. Cli apps should be replaced by console plugins.
+- 
+### UTC is used instead of GMT
+
+- PR: https://github.com/joomla/joomla-cms/pull/43912
+- Description: To unify the code base, all instances do use or fallback to UTC timezone. Make sure that your code doesn't do an check against GMT string.


### PR DESCRIPTION
### **User description**
See https://github.com/joomla/joomla-cms/pull/43912


___

### **PR Type**
documentation


___

### **Description**
- Added documentation to reflect the change from GMT to UTC in the codebase.
- Included a reference to the relevant PR for more details.
- Provided guidance on ensuring code compatibility with the new UTC standard.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>removed-backward-incompatibility.md</strong><dd><code>Documented the change from GMT to UTC in the codebase</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/54-60/removed-backward-incompatibility.md

<li>Added a new section about the change from GMT to UTC.<br> <li> Included a reference to the relevant PR.<br> <li> Provided a description of the change and its implications.<br>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/296/files#diff-1b9f27ae2f64c35bc2cdba1c2988613e48b706934385a2e51f36e0e1bd2d23b2">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

