### PR TITLE
[5.2] radio basic deprecate #43860

### DIFF
--- a/migrations/51-52/new-deprecations.md
+++ b/migrations/51-52/new-deprecations.md
@@ -30,5 +30,5 @@ Description: The `getData()` method in the `ArchiveModel.php` will be removed in
 ### RadiobasicField
 
 PR: https://github.com/joomla/joomla-cms/pull/43860
-Description: Based on the Issue #19299 and and PR #19320 the radiobasic field is pretty useless and can be removed.
+Description: Based on the Issue #19299 and PR #19320 the radiobasic field is pretty useless and can be removed.
 Decision in the maintainer meeting we deprecate the field in 5.x and move it to the b/c plugin in 6.0 and remove it in 7.0.

--- a/migrations/51-52/new-deprecations.md
+++ b/migrations/51-52/new-deprecations.md
@@ -26,3 +26,9 @@ Related PR: https://github.com/joomla/joomla-cms/pull/43304
 PR: https://github.com/joomla/joomla-cms/pull/43354
 File: /components/com_content/src/Model/ArchiveModel.php
 Description: The `getData()` method in the `ArchiveModel.php` will be removed in 7.0. Use `getItems()` instead.
+
+### RadiobasicField
+
+PR: https://github.com/joomla/joomla-cms/pull/43860
+Description: Based on the Issue #19299 and and PR #19320 the radiobasic field is pretty useless and can be removed.
+Decision in the maintainer meeting we deprecate the field in 5.x and move it to the b/c plugin in 6.0 and remove it in 7.0.


### PR DESCRIPTION
### **PR Type**
documentation


___

### **Description**
- Added a deprecation notice for the `RadiobasicField` in the migration guide.
- Provided context with references to related PR and issue.
- Outlined the deprecation timeline: deprecated in 5.x, moved to b/c plugin in 6.0, and removed in 7.0.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>new-deprecations.md</strong><dd><code>Document deprecation of `RadiobasicField` in migration guide</code></dd></summary>
<hr>

migrations/51-52/new-deprecations.md

<li>Added deprecation notice for <code>RadiobasicField</code>.<br> <li> Included PR and issue references for context.<br> <li> Detailed the timeline for deprecation and removal.<br>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/298/files#diff-894f01f35659eebe6f56513469c243be1f46564b966a738316201aef47317f52">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

