### PR TITLE
Added commas to Web Asset Manager docs

### DIFF
--- a/versioned_docs/version-5.1/general-concepts/web-asset-manager.md
+++ b/versioned_docs/version-5.1/general-concepts/web-asset-manager.md
@@ -456,7 +456,7 @@ Example json definition of ES6 module script, with fallback to legacy:
     "defer": true
   },
   "dependencies": ["core"]
-}
+},
 {
   "name": "foobar",
   "type": "script",


### PR DESCRIPTION
### **User description**
Seems the JSON was invalid so I fixed it.


___

### **PR Type**
documentation


___

### **Description**
- Fixed a JSON syntax error in the Web Asset Manager documentation by adding a missing comma.
- Ensured the JSON example is valid and correctly formatted.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>web-asset-manager.md</strong><dd><code>Fix JSON syntax in Web Asset Manager documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

versioned_docs/version-5.1/general-concepts/web-asset-manager.md

<li>Added a missing comma in a JSON example.<br> <li> Ensured JSON validity in the documentation.<br>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/305/files#diff-2b8905b01e4cd6060a31e3703f5e897a730f5208a058e9f03dfe787fd459019d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

