### PR TITLE
Fix display of docusaurus title in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Don't use subdirectory names which match somewhat the parent directory name. For
 
 You won't see the effect of these when you preview the Markdown text, but you will see them by previewing the Pull Request. 
 
-[Front Matter](https://docusaurus.io/docs/next/markdown-features#front-matter) should be used for titles and position in the left-hand sidebar:
+[Front Matter](https://docusaurus.io/docs/markdown-features#front-matter) should be used for titles and position in the left-hand sidebar:
 
 ```
 ---
@@ -106,18 +106,20 @@ sidebar-position: 2
 ---
 ```
 
-[Code blocks](https://docusaurus.io/docs/next/markdown-features/code-blocks) are enclosed in 3 backticks, and can have a title:
-```php title="hello.php"
-public static function hello() 
-{
-    echo "Hello!"; 
-}
-```
+[Code blocks](https://docusaurus.io/docs/markdown-features/code-blocks) are enclosed in 3 backticks, and can have a [title](https://docusaurus.io/docs/markdown-features/code-blocks#code-title)
+
+    ```php title="hello.php"
+    public static function hello() 
+    {
+        echo "Hello!"; 
+    }
+    ```
+
 Line numbering and highlighting of individual lines are also supported.
 
 To aid readability of the markdown please leave a blank line before and after code blocks.
 
-[Admonitions](https://docusaurus.io/docs/next/markdown-features/admonitions) 
+[Admonitions](https://docusaurus.io/docs/markdown-features/admonitions) 
 We don't use blank lines around content, and we add 2 spaces before the text messages.
 
 ```


### PR DESCRIPTION
### **User description**
The markdown wasn't showing how to use the title= on code blocks.

Plus docusaurus links changed to use current version rather than next.


___

### **PR Type**
documentation


___

### **Description**
- Updated Docusaurus links in the README to point to the current version instead of 'next'.
- Improved the display of code block titles by adding a link to the relevant section in the Docusaurus documentation.
- Enhanced the readability of the markdown by adjusting the formatting of code blocks.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update Docusaurus links and code block title display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Updated Docusaurus links to use the current version instead of 'next'.<br> <li> Improved the display of code block titles in the documentation.<br> <li> Added a link to the code title section in the Docusaurus <br>documentation.<br>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/309/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+12/-10</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

