### PR TITLE
Update quicktasklink.md

### DIFF
--- a/docs/building-extensions/components/quicktasklink.md
+++ b/docs/building-extensions/components/quicktasklink.md
@@ -1,7 +1,7 @@
 Quicktask Link and Icon
 =======================
 
-In general, a component has has one or more links to its views. They are defined in the manifest file and added to the menu during installation.
+In general, a component has one or more links to its views. They are defined in the manifest file and added to the menu during installation.
 
 ```xml title="A link to your component "
 <administration>
@@ -16,49 +16,66 @@ Sometimes it is useful to add a so called <strong>quicktask link</strong> which 
 You can see this for Joomla core components, for example articles in com_content, here the quicktask is the plus icon and lets you add a new article in a single click.
 Your menu link is added in the manfest file during installation.
 
-## Qicktask link
+## Quicktask Link and Title
 
-A quicktask link and icon are added as params to a menu item.
+A quicktask link and title are added as params to a menu item.
 
-```xml title="Qicktask Link and icon"
-	<menu link="option=com_example&amp;view=examples">
-		COM_EXAMPLE
-		<params>
-			<menu-quicktask-title>COM_EXAMPLE_MENU_QUICKTASK_TITLE</menu-quicktask-title>
-			<menu-quicktask>index.php?option=com_example&amp;view=example&amp;layout=edit</menu-quicktask>
-		</params>
-	</menu>
+```xml title="Quicktask Link and title"
+<menu link="option=com_example&amp;view=examples">
+    COM_EXAMPLE
+    <params>
+        <menu-quicktask-title>COM_EXAMPLE_MENU_QUICKTASK_TITLE</menu-quicktask-title>
+        <menu-quicktask>index.php?option=com_example&amp;view=example&amp;layout=edit</menu-quicktask>
+    </params>
+</menu>
+```
+The title translation string needs to appear in the language `.sys.ini` file for the extension
 
+## Quicktask Icon
+
+The default icon is the '+' sign indicating create a new item as this is the most common usage in the built-in compponents. 
+
+You can specify a different icon, either as a simple name for the built in common aliased icons (the `icon-` prefix will be automatically added), or as the font-awesome specification. 
+
+```xml title="Quicktask Link and icon"
+<menu link="option=com_example&amp;view=examples">
+    COM_EXAMPLE
+    <params>
+        <menu-quicktask-title>COM_EXAMPLE_MENU_QUICKTASK_TITLE</menu-quicktask-title>
+        <menu-quicktask-icon>eye</menu-quicktask-icon>
+        <menu-quicktask>index.php?option=com_example&amp;view=example&amp;layout=view</menu-quicktask>
+    </params>
+</menu>
 ```
 
 ## Example 
 
-This example shows a complete menu entry with dashboard, submenu and a quicktask.
+This example shows a complete menu entry with dashboard, submenu and a quicktask. The second item with a quicktask includes a fontawesome icon that has not been aliased.
 
 ```xml
-		<menu>
-			COM_EXAMPLE
-			<params>
-				<dashboard>example</dashboard>
-			</params>
-		</menu>
-		<submenu>
-			<menu link="option=com_example">
-				COM_EXAMPLE_MENU
-				<params>
-					<menu-quicktask-title>COM_EXAMPLE_MENU_QUICKTASK_TITLE</menu-quicktask-title>
-					<menu-quicktask>index.php?option=com_example&amp;view=example&amp;layout=edit</menu-quicktask>
-				</params>
-			</menu>
-			<menu link="option=com_categories&amp;extension=com_example">
-				COM_EXAMPLE_MENU_CATEGORIES
-				<params>
-					<menu-quicktask-title>COM_EXAMPLE_MENU_CATEGORIES</menu-quicktask-title>
-					<menu-quicktask>index.php?option=com_categories&amp;view=category&amp;layout=edit&amp;extension=com_example</menu-quicktask>
-				</params>
-			</menu>
-			<menu link="option=com_fields&amp;view=fields&amp;context=com_example,example">COM_EXAMPLE_MENU_FIELDS</menu>
-			<menu link="option=com_fields&amp;view=groups&amp;context=com_example,example">COM_EXAMPLE_MENU_FIELDS_GROUP</menu>
-		</submenu>
-
+<menu>
+    COM_EXAMPLE
+    <params>
+        <dashboard>example</dashboard>
+    </params>
+</menu>
+<submenu>
+    <menu link="option=com_example">
+        COM_EXAMPLE_MENU
+        <params>
+            <menu-quicktask-title>COM_EXAMPLE_MENU_QUICKTASK_TITLE</menu-quicktask-title>
+            <menu-quicktask>index.php?option=com_example&amp;view=example&amp;layout=edit</menu-quicktask>
+        </params>
+    </menu>
+    <menu link="option=com_categories&amp;extension=com_example">
+        COM_EXAMPLE_MENU_CATEGORIES
+        <params>
+            <menu-quicktask-title>COM_EXAMPLE_MENU_CATEGORIES</menu-quicktask-title>
+            <menu-quicktask-icon>fas fa-person-hiking</menu-quicktask-icon>
+            <menu-quicktask>index.php?option=com_categories&amp;view=category&amp;layout=edit&amp;extension=com_example</menu-quicktask>
+        </params>
+    </menu>
+    <menu link="option=com_fields&amp;view=fields&amp;context=com_example,example">COM_EXAMPLE_MENU_FIELDS</menu>
+    <menu link="option=com_fields&amp;view=groups&amp;context=com_example,example">COM_EXAMPLE_MENU_FIELDS_GROUP</menu>
+</submenu>
 ```

--- a/versioned_docs/version-5.1/building-extensions/components/quicktasklink.md
+++ b/versioned_docs/version-5.1/building-extensions/components/quicktasklink.md
@@ -16,11 +16,11 @@ Sometimes it is useful to add a so called <strong>quicktask link</strong> which 
 You can see this for Joomla core components, for example articles in com_content, here the quicktask is the plus icon and lets you add a new article in a single click.
 Your menu link is added in the manfest file during installation.
 
-## Qicktask link
+## Quicktask Link and Title
 
-A quicktask link and icon are added as params to a menu item.
+A quicktask link and title are added as params to a menu item.
 
-```xml title="Qicktask Link and icon"
+```xml title="Qicktask Link and title"
 	<menu link="option=com_example&amp;view=examples">
 		COM_EXAMPLE
 		<params>
@@ -30,10 +30,29 @@ A quicktask link and icon are added as params to a menu item.
 	</menu>
 
 ```
+NB the title translation string needs to appear in the language `.sys.ini` file for the extension
+
+## Quicktask Icon
+
+The default icon is the '+' sign indicating create a new item as this is the most common usage in the built-in compponents. 
+
+You can specify a different icon, either as a simple name for the built in common aliased icons (the `icon-` prefix will be automatically added), or as the font-awesome specification. 
+
+```xml title="Qicktask Link and icon"
+	<menu link="option=com_example&amp;view=examples">
+		COM_EXAMPLE
+		<params>
+			<menu-quicktask-title>COM_EXAMPLE_MENU_QUICKTASK_TITLE</menu-quicktask-title>
+			<menu-quicktask-icon>eye</menu-quicktask-icon>
+			<menu-quicktask>index.php?option=com_example&amp;view=example&amp;layout=view</menu-quicktask>
+		</params>
+	</menu>
+
+```
 
 ## Example 
 
-This example shows a complete menu entry with dashboard, submenu and a quicktask.
+This example shows a complete menu entry with dashboard, submenu and a quicktask. The second item with a quicktask includes a fontawesome icon that has not been aliased.
 
 ```xml
 		<menu>
@@ -54,6 +73,7 @@ This example shows a complete menu entry with dashboard, submenu and a quicktask
 				COM_EXAMPLE_MENU_CATEGORIES
 				<params>
 					<menu-quicktask-title>COM_EXAMPLE_MENU_CATEGORIES</menu-quicktask-title>
+					<menu-quicktask-icon>fas fa-person-hiking</menu-quicktask-icon>
 					<menu-quicktask>index.php?option=com_categories&amp;view=category&amp;layout=edit&amp;extension=com_example</menu-quicktask>
 				</params>
 			</menu>

--- a/versioned_docs/version-5.1/building-extensions/components/quicktasklink.md
+++ b/versioned_docs/version-5.1/building-extensions/components/quicktasklink.md
@@ -1,7 +1,7 @@
 Quicktask Link and Icon
 =======================
 
-In general, a component has has one or more links to its views. They are defined in the manifest file and added to the menu during installation.
+In general, a component has one or more links to its views. They are defined in the manifest file and added to the menu during installation.
 
 ```xml title="A link to your component "
 <administration>
@@ -20,65 +20,62 @@ Your menu link is added in the manfest file during installation.
 
 A quicktask link and title are added as params to a menu item.
 
-```xml title="Qicktask Link and title"
-	<menu link="option=com_example&amp;view=examples">
-		COM_EXAMPLE
-		<params>
-			<menu-quicktask-title>COM_EXAMPLE_MENU_QUICKTASK_TITLE</menu-quicktask-title>
-			<menu-quicktask>index.php?option=com_example&amp;view=example&amp;layout=edit</menu-quicktask>
-		</params>
-	</menu>
-
+```xml title="Quicktask Link and title"
+<menu link="option=com_example&amp;view=examples">
+    COM_EXAMPLE
+    <params>
+        <menu-quicktask-title>COM_EXAMPLE_MENU_QUICKTASK_TITLE</menu-quicktask-title>
+        <menu-quicktask>index.php?option=com_example&amp;view=example&amp;layout=edit</menu-quicktask>
+    </params>
+</menu>
 ```
-NB the title translation string needs to appear in the language `.sys.ini` file for the extension
+The title translation string needs to appear in the language `.sys.ini` file for the extension
 
 ## Quicktask Icon
 
-The default icon is the '+' sign indicating create a new item as this is the most common usage in the built-in compponents. 
+The default icon is the '+' sign indicating create a new item as this is the most common usage in the built-in compponents.
 
-You can specify a different icon, either as a simple name for the built in common aliased icons (the `icon-` prefix will be automatically added), or as the font-awesome specification. 
+You can specify a different icon, either as a simple name for the built in common aliased icons (the `icon-` prefix will be automatically added), or as the font-awesome specification.
 
-```xml title="Qicktask Link and icon"
-	<menu link="option=com_example&amp;view=examples">
-		COM_EXAMPLE
-		<params>
-			<menu-quicktask-title>COM_EXAMPLE_MENU_QUICKTASK_TITLE</menu-quicktask-title>
-			<menu-quicktask-icon>eye</menu-quicktask-icon>
-			<menu-quicktask>index.php?option=com_example&amp;view=example&amp;layout=view</menu-quicktask>
-		</params>
-	</menu>
-
+```xml title="Quicktask Link and icon"
+<menu link="option=com_example&amp;view=examples">
+    COM_EXAMPLE
+    <params>
+        <menu-quicktask-title>COM_EXAMPLE_MENU_QUICKTASK_TITLE</menu-quicktask-title>
+        <menu-quicktask-icon>eye</menu-quicktask-icon>
+        <menu-quicktask>index.php?option=com_example&amp;view=example&amp;layout=view</menu-quicktask>
+    </params>
+</menu>
 ```
 
-## Example 
+## Example
 
 This example shows a complete menu entry with dashboard, submenu and a quicktask. The second item with a quicktask includes a fontawesome icon that has not been aliased.
 
 ```xml
-		<menu>
-			COM_EXAMPLE
-			<params>
-				<dashboard>example</dashboard>
-			</params>
-		</menu>
-		<submenu>
-			<menu link="option=com_example">
-				COM_EXAMPLE_MENU
-				<params>
-					<menu-quicktask-title>COM_EXAMPLE_MENU_QUICKTASK_TITLE</menu-quicktask-title>
-					<menu-quicktask>index.php?option=com_example&amp;view=example&amp;layout=edit</menu-quicktask>
-				</params>
-			</menu>
-			<menu link="option=com_categories&amp;extension=com_example">
-				COM_EXAMPLE_MENU_CATEGORIES
-				<params>
-					<menu-quicktask-title>COM_EXAMPLE_MENU_CATEGORIES</menu-quicktask-title>
-					<menu-quicktask-icon>fas fa-person-hiking</menu-quicktask-icon>
-					<menu-quicktask>index.php?option=com_categories&amp;view=category&amp;layout=edit&amp;extension=com_example</menu-quicktask>
-				</params>
-			</menu>
-			<menu link="option=com_fields&amp;view=fields&amp;context=com_example,example">COM_EXAMPLE_MENU_FIELDS</menu>
-			<menu link="option=com_fields&amp;view=groups&amp;context=com_example,example">COM_EXAMPLE_MENU_FIELDS_GROUP</menu>
-		</submenu>
-
+<menu>
+    COM_EXAMPLE
+    <params>
+        <dashboard>example</dashboard>
+    </params>
+</menu>
+<submenu>
+    <menu link="option=com_example">
+        COM_EXAMPLE_MENU
+        <params>
+            <menu-quicktask-title>COM_EXAMPLE_MENU_QUICKTASK_TITLE</menu-quicktask-title>
+            <menu-quicktask>index.php?option=com_example&amp;view=example&amp;layout=edit</menu-quicktask>
+        </params>
+    </menu>
+    <menu link="option=com_categories&amp;extension=com_example">
+        COM_EXAMPLE_MENU_CATEGORIES
+        <params>
+            <menu-quicktask-title>COM_EXAMPLE_MENU_CATEGORIES</menu-quicktask-title>
+            <menu-quicktask-icon>fas fa-person-hiking</menu-quicktask-icon>
+            <menu-quicktask>index.php?option=com_categories&amp;view=category&amp;layout=edit&amp;extension=com_example</menu-quicktask>
+        </params>
+    </menu>
+    <menu link="option=com_fields&amp;view=fields&amp;context=com_example,example">COM_EXAMPLE_MENU_FIELDS</menu>
+    <menu link="option=com_fields&amp;view=groups&amp;context=com_example,example">COM_EXAMPLE_MENU_FIELDS_GROUP</menu>
+</submenu>
 ```


### PR DESCRIPTION
### **User description**
Correct spelling typo in "Quicktask link" sub -head

Changed Quicktask link section text to refer to title which appears as a mouseover the icon, and to state that the language string needs to be in the .sys.ini lanuage file

Added new sub-section Quicktask Icon with explanation and example.

Added fontawesome icon example to the Example section

NB there is also a <quicktask-permission> tag but I can find no information how to use it.


___

### **PR Type**
documentation


___

### **Description**
- Corrected spelling errors in the "Quicktask Link" section headers.
- Expanded documentation to include details on specifying Quicktask titles and icons.
- Added a new subsection explaining how to use Quicktask Icons, including examples with FontAwesome.
- Clarified that the title translation string must be included in the language `.sys.ini` file.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>quicktasklink.md</strong><dd><code>Update Quicktask Link Documentation with Icons and Titles</code></dd></summary>
<hr>

versioned_docs/version-5.1/building-extensions/components/quicktasklink.md

<li>Corrected spelling errors in section headers.<br> <li> Added explanation for Quicktask title and icon.<br> <li> Included examples for specifying icons, including FontAwesome.<br> <li> Clarified the need for language strings in <code>.sys.ini</code> files.<br>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/310/files#diff-be6a5b8a4f4d358dd096ce2967b5dc74883b240b9dde1f3cb62bc5982b5b010d">+24/-4</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

