### PR TITLE
fix header levels and UTF across versions for building extensions area

### DIFF
--- a/docs/building-extensions/modules/module-development-tutorial/step10_abstract_module_dispatcher.md
+++ b/docs/building-extensions/modules/module-development-tutorial/step10_abstract_module_dispatcher.md
@@ -140,7 +140,7 @@ If you have more complex requirements then you may need to override more functio
 ## Updated Manifest File
 
 ```xml title="mod_hello/mod_hello.xml"
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <extension type="module" client="site" method="upgrade">
     <name>MOD_HELLO_NAME</name>
     <!-- highlight-next-line -->

--- a/docs/building-extensions/modules/module-development-tutorial/step11_update_server.md
+++ b/docs/building-extensions/modules/module-development-tutorial/step11_update_server.md
@@ -30,7 +30,7 @@ To associate mod_hello with an update server you need to add the following lines
 Your updated manifest file is thus:
 
 ```xml title="mod_hello/mod_hello.xml"
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <extension type="module" client="site" method="upgrade">
     <name>MOD_HELLO_NAME</name>
     <!-- highlight-next=line -->

--- a/docs/building-extensions/modules/module-development-tutorial/step5-config.md
+++ b/docs/building-extensions/modules/module-development-tutorial/step5-config.md
@@ -21,7 +21,7 @@ The source code is available at [mod_hello step 5](https://github.com/joomla/man
 The configuration is implemented by adding a section to the manifest file:
 
 ```xml title="mod_hello/mod_hello.xml"
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <extension type="module" client="site" method="upgrade">
     <name>MOD_HELLO_NAME</name>
     <!-- highlight-next-line -->

--- a/versioned_docs/version-4.4/building-extensions/components/mvc/library-mvc.md
+++ b/versioned_docs/version-4.4/building-extensions/components/mvc/library-mvc.md
@@ -2,10 +2,12 @@
 title: Library MVC Classes
 sidebar_position: 4
 ---
-# Joomla Library MVC Classes
+Joomla Library MVC Classes
+==========================
+
 Joomla provides several Controller, View and Model library classes, and this section gives an overview of these, and explains when your own component should use each class. However, it doesn't attempt to provide a full description of each class's functionality. The classes can be found in libraries/src/MVC.
 
-# Base MVC Classes
+## Base MVC Classes
 In practical terms, the lowest level classes you would be likely to use are:
 - BaseController in libraries/src/MVC/Controller/BaseController.php
 - HtmlView in libraries/src/MVC/View/HtmlView.php (for displaying web pages)
@@ -15,27 +17,27 @@ In practical terms, the lowest level classes you would be likely to use are:
 
 In general, using these base classes is a good option if your component is displaying a single item on a site page. 
 
-## BaseController
+### BaseController
 The functionality within BaseController includes: 
 - the `execute()` method described above, which runs the appropriate Controller function, based on the *task* parameter's `<method>` part (which is passed to it).
 - functions for determining the appropriate View and Model classes to use (based on the setting of the view parameter within the HTTP request), and getting the MVCFactory class to create them
 - a default `display()` method, which gets instances of the View and Model classes (including providing the View instance with a link to the Model instance), and then calls the `display()` method of the View class.
 
-## HtmlView
+### HtmlView
 The functionality within HtmlView includes: 
 - a default `display()` method, which runs the tmpl file
 - code for finding the tmpl file, taking into account a layout override which may have been put into the template folder structure
 - code for setting the model instance, and subsequently retrieving it
 
-## BaseDatabaseModel
+### BaseDatabaseModel
 The functionality within BaseDatabaseModel includes: 
 - code for getting an instance of the Table class (via the MVCFactory class)
 - base code for creating a model "state". This feature is useful if the component and/or several modules shown on the web page all use the same base data. In this case they may share the same Model instance and the model "state" acts like a container for sharing the values of items across the component and modules.
 
-# Higher-level Controller Classes
+## Higher-level Controller Classes
 There are 2 higher-level controller classes, each of which inherit from BaseController. 
 
-## AdminController 
+### AdminController 
 AdminController contains methods which handle the types of operations that can be performed on multiple items, for example:
 
 - delete
@@ -49,7 +51,7 @@ The name AdminController suggests that this controller is to be used only on the
 
 Note however that it doesn't support the operations enabled by the Batch button on e.g. the Content/Articles page; these POST requests are handled by the FormController.
 
-## FormController
+### FormController
 FormController contains methods which are associated with editing an individual item 
 
 - handling a request to edit an item – which involves checking that the user is allowed to edit the item and that it isn't already checked out, and if these checks pass then the item is checked out (if that component has enabled checkout) and a redirect is issued to display the edit form
@@ -60,14 +62,14 @@ FormController contains methods which are associated with editing an individual 
 
 The FormController is thus well suited to Actions 3 and 5 shown in the diagrams above in the [Post/Request/Get pattern](post-redirect-get.md) section.
 
-# Higher-level View Classes
+## Higher-level View Classes
 Apart from the CategoryFeedView, which is used for generating a [feed](https://docs.joomla.org/J3.x:Developing_an_MVC_Component/Adding_a_Feed), there are two higher level View classes in common usage:
 - CategoryView – for displaying a category and its children
 - CategoriesView – for displaying all the categories at a certain level in the category hierarchy, and the number of items associated with each category
 
 The two classes ListView and FormView seem to be aimed at functionality for displaying a list of records (like the `com_content` administrator View\Articles\HtmlView) and a form for editing a record (like the `com_content` administrator View\Article\HtmlView). However, at time of writing (Joomla 5 alpha has recently appeared), they aren't used by any of the Joomla components, so I wouldn't recommend using them, at least not yet.
 
-## Higher-level Model Classes
+### Higher-level Model Classes
 The diagram shows the inheritance tree of the Joomla library MVC models. 
 ![Model Class Hierarchy](_assets/model-hierarchy.jpg "Model Class Hierarchy")
 
@@ -87,32 +89,32 @@ Something to be aware of if you are using the same model across the "edit item" 
 
 When you're using the model because you're handling a POST (i.e. cases 3 and 5 in the diagram) then any effort expended in preparing the data for a web page is going to be wasted. (In fact, in the FormController `getModel()` method call, the parameter `$config` is set to `array('ignore_request' => true)` by default, which results in the model's `populateState` method not being run, to save this wasted effort.) 
 
-# Summary
+## Summary
 As we've seen, Joomla has rich functionality in higher level Controller and Model classes which can greatly simplify your code (all of which can be used on both the front end and back end). 
 
 The choice of which controller and model classes to extend is easier on the back end, because you just follow the pattern of the Joomla core components.
 
 For the front end here's a rough guide to choosing the most appropriate Controller and Model classes to extend; in each case you're using the standard HtmlView as base View class to extend.
 
-## Simple Display
+### Simple Display
 Simply displaying a record or a set of records, without providing the ability to change anything
 - Controller extends BaseController
 - Model extends BaseDatabaseModel or (particularly if you're sharing a model between a component and modules) ItemModel if it's a single record, ListModel if it's multiple records.
 
-## Displaying records, plus operations on selected records
+### Displaying records, plus operations on selected records
 Displaying a form with multiple records (but the form isn't defined in an XML file), including the providing the ability to select several records and apply some sort of operation to them (eg delete, publish):
 - Controller extends BaseController
 - Model extends ListModel – except if you're using the same model for displaying the form and handling the updates, in which case use AdminModel
 
-## Handling the HTTP POSTs from the above
+### Handling the HTTP POSTs from the above
 - Controller extends AdminController
 - Model extends AdminModel
 
-## Editing a record
+### Editing a record
 Displaying a form with a single record, where the form is defined in an XML file, and allowing the user to edit it, or a blank record and allowing the user to create a record:
 - Controller extends BaseController
 - Model extends FormModel – except if you're using the same model for displaying the form and handling the updates (as is usually the case), in which case use AdminModel
 
-## Handling the HTTP POSTs from the above
+### Handling the HTTP POSTs from the above
 - Controller extends FormController
 - Model extends AdminModel

--- a/versioned_docs/version-4.4/building-extensions/components/mvc/mvc-factory.md
+++ b/versioned_docs/version-4.4/building-extensions/components/mvc/mvc-factory.md
@@ -2,7 +2,10 @@
 title: The MVC Factory Class
 sidebar_position: 2
 ---
-# MVC Factory Overview
+
+MVC Factory Overview
+====================
+
 The MVC Factory class is used within Joomla to create instances of component Controller, View, Model and Table classes. 
 
 Each component has its own MVCFactory class instance, which is instantiated passing in that component's [namespace prefix](../../../general-concepts/namespaces/defining-your-namespace.md). 
@@ -27,10 +30,10 @@ $model = $this->getModel('example', 'administrator');
 ```
 Note that if your component is running in the front end (site) you can still use the administrator model, and if it's running in the back end (administrator) you can still use the site model. There is no restriction. 
 
-# Creating the MVCFactory class instance
+## Creating the MVCFactory class instance
 Your component's MVCFactory is created by defining it as a dependendency in your services/provider.php file, as described in [Dependency Injection](../../../general-concepts/dependency-injection/index.md), but you don't have to understand all the intricacies of Joomla Dependency Injection to use it effectively.
 
-# Creating your Controller class instance
+## Creating your Controller class instance
 
 As described in [Extension and Dispatcher Classes](../../../general-concepts/extension-and-dispatcher/index.md), your Controller class is instantiated within the `dispatch` function of the ComponentDispatcher class. It has an instance variable pointing to the MVCFactory class and will call:
 ```php
@@ -46,7 +49,7 @@ In this diagram (and in the next):
 - the solid black lines represent method calls
 - the thick solid red lines represent where a Factory class instantiates a class
 
-# Creating your View, Model and Table class instances
+## Creating your View, Model and Table class instances
 
 ![Instantiating View, Model, Table](_assets/mvc-factory.jpg "Instantiating View, Model, Table")
 
@@ -59,7 +62,7 @@ The View can also get the Model via a `getModel` call, but only if the Controlle
 $view->setModel($model);
 ```
 
-# Default names for View, Model and Table classes
+## Default names for View, Model and Table classes
 While the name for the Controller is taken from the *task* parameter, the default names for the View, Model and Table classes are taken from the *view* parameter. These default classes are what will be instantiated if you just call `getView()`, `getModel()` and `getTable()` without any parameters. 
 
 So, for example, the names of the classes created for a request with URL query "?option=com_example&view=viewname" and no *task* parameter will be:
@@ -68,7 +71,7 @@ So, for example, the names of the classes created for a request with URL query "
 - `<namespace>\Model\ViewnameModel`
 - `<namespace>\Table\ViewnameTable`
 
-# Summary
+## Summary
 We've covered a fair bit of background in this section, to give you an understanding of why things work, but it's all to make it easy for you in your MVC classes.
 
 In your Controller, you can create the View and the Model, and give the View a reference to the Model:
@@ -100,7 +103,7 @@ $table = $this->getTable();           // if your Table class matches the view= p
 $table = $this->getTable('example');  // to get the ExampleTable class
 ```
 
-# Issues
+## Issues
 A key reason for the introduction of the MVCFactory class was to remove the use of the `static::getInstance()` calls to obtain an instance of one of the MVC classes. However, you may find one or two problems with the approach.
 
 For example, when saving a database record in the Table class (eg in `Joomla\CMS\Table\Content::store()`), Joomla obtains another instance of that Table class in order to verify that the alias which is about to be saved is unique. However, when the Table instance is created it isn't passed a pointer to the MVCFactory instance, so it can't create another instance using the MVCFactory's `createTable` function. In Joomla 4 the solution was to use the deprecated `getInstance()` function:

--- a/versioned_docs/version-4.4/building-extensions/components/mvc/mvc-overview.md
+++ b/versioned_docs/version-4.4/building-extensions/components/mvc/mvc-overview.md
@@ -2,14 +2,18 @@
 title: MVC Overview
 sidebar_position: 1
 ---
-# MVC Overview
+MVC Overview
+============
+
 The diagram below depicts the MVC pattern as it's used in Joomla. This applies to both the admin back end and the site front end.
 
 ![MVC Overview](_assets/mvc-overview.jpg "MVC Overview")
 
+## Basic Elements
+
 In this section we will cover the 4 types of classes shown in the diagram. In your component you're likely to have several Controller, View and Model classes, and (if your component uses its own table or tables in the database) one Table class for each database table your component has. 
 
-## Controller
+### Controller
 Your Controller code is run whenever there's an incoming HTTP request which is routed to your component. The controller is responsible for analysing the user's request, checking that the user is allowed to perform that action and determining how to satisfy the request. The latter could involve:
 
 - determining which Model (or Models) will be needed to satisfy the request, and creating an instance of that Model
@@ -17,7 +21,7 @@ Your Controller code is run whenever there's an incoming HTTP request which is r
 - determining which View should be used to present the web page to the user, and creating an instance of that View or
 - if instead the user should receive a redirect to another URL, then determining that redirect URL.
 
-## View
+### View
 The MVC View functionality is split into 2 files
 
 1. A View class file, which is usually just known as the View, and after this we'll just call it the View
@@ -35,19 +39,19 @@ This means that if the View holds the response data in, for example, `$this->ite
 
 Separating the View and tmpl like this enables another level of flexibility, as you can easily set up a layout override to output the View data using your own preferred HTML. 
 
-## Model
+### Model
 The Model encapsulates the data used by the component. In most cases this data will come from a database, either the Joomla database, or some external database, but it is also possible for the Model to obtain data from other sources, such as via a web services API running on another server. The Model is also responsible for updating the database where appropriate. The purpose of the Model is to isolate the Controller and View from the details of how data is obtained or amended.
 
 If the component is displaying a form which is defined in XML using the Joomla Form approach, the Model handles the setting-up and configuration of the `Form` instance, ready for the tmpl to output fields using `$form->renderField()` etc. 
 
-## Table
+### Table
 If your extension has one or more database tables, then you should have a Table class for each database table. Your Table class will inherit from the Joomla library Table class, which provides CRUD (Create / Read / Update / Delete) access to the underlying database table.
 
 The Table class provides access to individual records only, so it would be used by the Model if the requirement was a CRUD operation on an individual record, eg to create or update a record in the database.
 
 If instead it's required to access several records in the database table, then the Model would access the database directly, rather than using the Table class.
 
-# The HTTP Request *task* Parameter
+## The HTTP Request *task* Parameter
 Joomla uses the HTTP Request *task* parameter to determine which controller should be used. The *task* parameter can be sent in an HTTP GET or an HTTP POST - Joomla doesn't mind which - and it's just an ordinary HTTP parameter, nothing special. 
 
 The *task* parameter is of the form `<controllerType>.<method>`. The first part identifies the particular Controller class to use, and the second part identifies that class's instance method to call.
@@ -58,7 +62,7 @@ If the task parameter is not set at all then the `display()` method in the Displ
 
 We'll look at some examples later on.
 
-# Your MVC within Joomla
+## Your MVC within Joomla
 Of course, your component's MVC code runs within the context of Joomla's library code, really like the meat in a sandwich. When Joomla determines that it should run your component, then it obtains your component's Extension and Dispatcher classes, and it's the `dispatch()` function of the Joomla ComponentDispatcher class which actually analyses the *task* parameter to determine which of your Controller classes to instantiate, as described in [Extension and Dispatcher classes](../../../general-concepts/extension-and-dispatcher/index.md). Then `dispatch()` calls your component's `execute()` method, passing the `<method>` part of the *task* parameter. Assuming your component has Joomla\CMS\MVC\Controller\BaseController in its inheritance chain, then this will result (in the normal case) in your Controller's `method` function being called. 
 
 After the `execute()` method completes the `dispatch()` method will call the Controller's `redirect()` method - we'll see the significance of this later. 

--- a/versioned_docs/version-4.4/building-extensions/components/mvc/post-redirect-get.md
+++ b/versioned_docs/version-4.4/building-extensions/components/mvc/post-redirect-get.md
@@ -2,22 +2,25 @@
 title: Post-Request-Get Pattern
 sidebar_position: 3
 ---
-# Post-Request-Get Pattern
+
+Post-Request-Get Pattern
+========================
+
 Joomla follows the [Post/Redirect/Get pattern](https://en.wikipedia.org/wiki/Post/Redirect/Get), which means that when a user submits a form in an HTTP POST, then rather than Joomla responding to the POST with an HTML page, it redirects to another page which the browser will access with an HTTP GET. In this section we'll look at a couple of examples of this, and see how it aligns with the use of the *task* parameter, and later with the Joomla library MVC classes.
 
 Although Joomla uses the Post-Request-Get Pattern extensively, this doesn't mean that you have to use it everywhere in your own component. For example, if your component has a front-end form which is used to submit an order, then it may make perfect sense to provide the order confirmation text as the HTTP response to the HTTP POST of the order submission. 
 
-# Example 1 Publish Articles
+## Example 1 Publish Articles
 The diagram shows the steps associated within publishing articles on the Joomla back-end. You'll probably find it helpful to perform these operations on your own Joomla instance, and use your browser's devtools to examine the HTTP requests and responses. 
 
 ![Publishing Articles](_assets/post-request-get1.jpg "Publishing Articles")
 
-## Action 1
+### Action 1
 The administrator clicks on Content / Articles to display the list of articles. This is simply an HTTP GET request to the `com_content` administrator webpage with the `view` parameter set to `articles`. (If SEF URLs are being used, then it's the Joomla Router which will set up the `view` parameter, based on parsing the incoming URL). The *task* parameter is not set in this HTTP request, and so the `com_content` DisplayController is instantiated and the `display()` method called. Based on the `view` parameter, the default View class is Joomla\Component\Content\Administrator\View\\**Articles**\HtmlView, and the default Model is Joomla\Component\Content\Administrator\Model\\**Articles**Model.
 
 A key thing to note is that this view displays various buttons at the top of the form. When you select one or more articles, then these buttons become visible in the Actions button drop-down at the top of the page. It is these buttons which trigger an HTTP POST to the server, and embedded within the buttons is what the *task* parameter gets set to within that POST request.  
 
-## Action 2
+### Action 2
 The administrator selects a number of articles and then presses the Publish button. At this point it's worth switching on your browser's devtools, and examining the messages. You'll see that pressing Publish triggers:
 - an HTTP POST request to the server with
 - the *task* parameter set to "articles.publish"
@@ -85,28 +88,28 @@ to get the `<method>` part of the *task* parameter, in order to code the differe
 
 Secondly, did you notice how much of the code to handle the publish operation was actually within the `com_content` code? Very little! Practically all the code was within the Joomla library MVC classes. Making judicious choices in how you name your component's fields and how your component's MVC classes extend the Joomla library classes can make it easy for you to include functionality with very little coding effort. We'll look at the Joomla library MVC classes in more detail in the next section.
 
-## Action 1 again
+### Action 1 again
 The URL redirect at the end of Action 2 results in the display of the list of articles again. However, this time the user will see a message like "2 articles published" at the top of the form. 
 
 There may be 2 administrators logged on simultaneously, and both displaying the list of articles around the same time. How does Joomla know which administrator should be shown the "2 articles published" message? The answer is that it uses cookies. When the administrator's browsers sends the HTTP GET request to display the list of articles it sends in the request all the cookies which the server previously sent to it. One of these will be used by the Joomla Session functionality as an index to the Session data which is stored for that user. The `enqueueMessage` function described above stores a message within this session data, and when Joomla processes the next HTTP request it will see that there's a message stored there and will output it to the page.
 
 You can see what's stored in your session data by switching on Joomla Debug in the global configuration, and then clicking on the little Joomla symbol at the bottom left of each web page. However you won't see any enqueued messages because when Joomla outputs an enqueued message it removes it from the session, so that it isn't displayed again on the next HTTP request. 
 
-# Example 2 Edit Article
+## Example 2 Edit Article
 ![Editing Articles](_assets/post-request-get2.jpg "Editing Articles")
 
-## Action 1
+### Action 1
 This is the same as above, displaying the list of articles.
 
-## Action 3
+### Action 3
 The administrator clicks on an article to edit it. If you switch off Search Engine Friendly (SEF) URLs in your Global Configuration / Site parameters, then you'll see that the link behind each article title is something like `http://yourdomain.org/administrator/index.php?option=com_content&task=article.edit&id=1`. So the HTTP GET request sent to the server will have *task* set to "article.edit", and this will result in the `com_content` ArticleController being instantiated, and its `edit()` function being called.
 
 Similar to what we found previously, there's no `edit` function within ArticleController.php, so what is run is the `edit` function in the class it extends, namely Joomla\CMS\MVC\Controller\FormController in libraries/src/MVC/Controller/FormController.php. It basically checks that the user is allowed to perform this operation, and if so, checks the content record out (by setting the `checked_out` and `checked_out_time` columns in the article record in the database), and sets up a redirect to display the article edit form.
 
-## Action 4
+### Action 4
 The redirect results in an HTTP GET to a URL like http://yourdomain.org/administrator/index.php?option=com_content&view=article&layout=edit&id=1. The *task* parameter is not set so this will be handled by the `com_content` DisplayController, in the `display()` function. It will use the `com_content` Article View class in src/View/Article/HtmlView.php, and the tmpl file used will be tmpl/article/edit.php (from the `layout` parameter). This displays the form for editing a single article.
 
-## Action 5
+### Action 5
 When the administrator clicks on `Save & Close` then this will result in an HTTP POST to the server, with the article's field values, and *task* set to "article.save". This will be routed to the `com_content` ArticleController, and its `save()` function. Once again the `save` function is absent, so it drops back to using the `save` function in the class which ArticleController extends, namely Joomla\CMS\MVC\Controller\FormController in libraries/src/MVC/Controller/FormController.php. This function does the following (in its 'happy path'):
 - checks the user is allowed to perform the operation
 - validates the data (ie the submitted article fields) 
@@ -115,6 +118,6 @@ When the administrator clicks on `Save & Close` then this will result in an HTTP
 - enqueues a confirmation message that the save succeeded
 - sets up a redirect back to the form showing the list of articles
 
-## Action 1 again
+### Action 1 again
 As before, this displays the list of articles, plus the enqueued message.
 

--- a/versioned_docs/version-4.4/building-extensions/index.md
+++ b/versioned_docs/version-4.4/building-extensions/index.md
@@ -3,13 +3,14 @@ sidebar_position: 5
 ---
 Build Extensions
 ================
+
 Joomla is a rich featured content management system, but if you're building a website with Joomla and you need extra features which aren't available by default, then you can easily extend it with extensions. There are five common types of extensions for Joomla: Components, Modules, Plugins, Templates, and Languages. There are three others: Packages, Files and Libraries. Each of these extensions handle specific functionality (many built-in features of Joomla are implemented using extensions).
 
 The difference between Joomla components, modules, plugins and templates can be initially confusing. If you're new to Joomla then you may find it useful to watch the video [How Joomla Works - a guide for extension developers](https://youtu.be/JKnq47Yhtvs), which describes how these 4 types of extension fit into the generation of a Joomla web page. Their output is also highlighted in different colours in the diagram below. 
 
 ![Screenshot showing extension types](./_assets/screenshot-extension-types.jpg)
 
-# Components
+## Components
 [Components](./components/index.md) provide the central part of a web page on a Joomla site; each site web page displays the output from one component. They can be thought of as mini applications. Most components have two parts: a site part and an administrator part. For example, `com_content` is the component which handles articles; on the site front-end `com_content` displays articles to website visitors and on the back-end `com_content` provides the functionality for administrators to edit articles. 
 
 In general, components manage the data of the Joomla instance and provide functionality for creating, editing, removing and displaying the data. Often the data management aspects are handled in the administrator back-end and the site front-end simply displays the data, but this split of responsibility is not mandated, and some components provide front-end functionality for creating/editing/removing data.
@@ -21,7 +22,7 @@ When you navigate to a certain page on a site or perform a certain operation suc
 
 Examples of component functionality available from third party extensions include backup utilities and support for eCommerce. 
 
-# Modules
+## Modules
 [Modules](./modules/index.md) are more lightweight and flexible extensions displayed on a web page. Modules are mostly known as the “boxes” that are arranged around a component, for example: the login module or the breadcrumbs module. Modules are assigned per menu item. So you can decide to show or hide the login module depending on which menu item the user is viewing. 
 
 A module can often be a companion to the component. For example, if your web page displays an article (`com_content` component) then you might have a module (`mod_tags_similar`) in the sidebar which displays links to related articles, or a module which displays an image slider of related photos.
@@ -33,32 +34,32 @@ However, modules do not need to be linked to components, as a matter of fact the
 
 If you're just beginning with Joomla extension development then developing a module is the easiest place to start. 
 
-# Plugins
+## Plugins
 [Plugins](./plugins/index.md) work behind the scenes to modify or enhance the basic Joomla functionality. In the execution of any part of Joomla - be it the core, a module or a component - an event can be triggered. When an event is triggered, plugins which are registered to handle that event execute, and are passed data related to that event. The plugin can then, for example, modify the data and return it to the core Joomla code. For example, a plugin could be used to intercept user-submitted articles and filter out bad words.
 
 - Examples: Content pagenavigation plugin (which generates the Prev and Next links as shown in the screenshot above)
 - Management feature: Admin menu → System → Plugins
 
-# Templates
+## Templates
 A [template](./templates/index.md) is basically the design of your Joomla-powered website. With a template you define the look and feel of your website, primarily based on CSS. Templates have certain fields in which the component (just one) and modules (as many as you like) will be shown. Building a complete Joomla template from scratch is difficult because you have to understand the variety of HTML output by the Joomla components, and the CSS classes which are used within them. However, it is relatively easy to customize the Atum (administrator) and Cassiopeia (site) templates which are shipped with Joomla, particularly as you can use the Joomla child template functionality to simply specify deviations from the parent template. 
 
 - Management feature: Admin menu → System → Templates
 
-# Languages
+## Languages
 Probably the most basic extensions are languages. Languages can be packaged in two ways: either as a core package or as an extension package. In essence, both the core and the extension language package files consist of key/value pairs, which provide the translation of static text strings, assigned within the Joomla source code. These language packs will affect both the front and administrator side of your Joomla instance. Note: these language packs also include an XML meta file which describes the language.
 
 - Management feature: Admin menu → System → Manage / Languages
 
-# Libraries
+## Libraries
 Libraries are standalone PHP snippets that Joomla uses. Note nearly all of Joomla's core code is available as a library within the libraries/src folder. All composer libraries (such as PHPMailer) are installed as a library "vendor" within libraries/vendor. Many of the most popular 3rd party extensions in Joomla use libraries to reuse common functionality across their components. 
 
-# File
+## File
 The File extension type is used to install individual files into a directory of the Joomla instance. There are no examples in Joomla Core of this type and it is the least used type, however it can be used for example to place [custom scripts](./custom-script/index.md) into the Joomla cli directory or to place template overrides into a specific directory. 
 
-# Packages
+## Packages
 Packages are simply a group of any of the above types of extensions. A common use of a package would be to ship a template that also bundles a system plugin. Or a component that also installs a library it uses. In Joomla many language packs install as a package so that the frontend and backend languages can be installed independently. 
 
-# Extension Installation
+## Extension Installation
 There are 4 methods of installing an extension. You can install from the Joomla Extension Directory (Install from Web), upload the zip file of an extension, install from a folder or install from a URL. 
 
 ![Screenshot showing installing an extension](./_assets/screenshot-install-extension.jpg)

--- a/versioned_docs/version-4.4/building-extensions/modules/module-development-tutorial/step10_abstract_module_dispatcher.md
+++ b/versioned_docs/version-4.4/building-extensions/modules/module-development-tutorial/step10_abstract_module_dispatcher.md
@@ -140,7 +140,7 @@ If you have more complex requirements then you may need to override more functio
 ## Updated Manifest File
 
 ```xml title="mod_hello/mod_hello.xml"
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <extension type="module" client="site" method="upgrade">
     <name>MOD_HELLO_NAME</name>
     <!-- highlight-next-line -->

--- a/versioned_docs/version-4.4/building-extensions/modules/module-development-tutorial/step11_update_server.md
+++ b/versioned_docs/version-4.4/building-extensions/modules/module-development-tutorial/step11_update_server.md
@@ -30,7 +30,7 @@ To associate mod_hello with an update server you need to add the following lines
 Your updated manifest file is thus:
 
 ```xml title="mod_hello/mod_hello.xml"
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <extension type="module" client="site" method="upgrade">
     <name>MOD_HELLO_NAME</name>
     <!-- highlight-next=line -->

--- a/versioned_docs/version-4.4/building-extensions/modules/module-development-tutorial/step5-config.md
+++ b/versioned_docs/version-4.4/building-extensions/modules/module-development-tutorial/step5-config.md
@@ -21,7 +21,7 @@ The source code is available at [mod_hello step 5](https://github.com/joomla/man
 The configuration is implemented by adding a section to the manifest file:
 
 ```xml title="mod_hello/mod_hello.xml"
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <extension type="module" client="site" method="upgrade">
     <name>MOD_HELLO_NAME</name>
     <!-- highlight-next-line -->

--- a/versioned_docs/version-5.0/building-extensions/components/mvc/library-mvc.md
+++ b/versioned_docs/version-5.0/building-extensions/components/mvc/library-mvc.md
@@ -2,10 +2,12 @@
 title: Library MVC Classes
 sidebar_position: 4
 ---
-# Joomla Library MVC Classes
+Joomla Library MVC Classes
+==========================
+
 Joomla provides several Controller, View and Model library classes, and this section gives an overview of these, and explains when your own component should use each class. However, it doesn't attempt to provide a full description of each class's functionality. The classes can be found in libraries/src/MVC.
 
-# Base MVC Classes
+## Base MVC Classes
 In practical terms, the lowest level classes you would be likely to use are:
 - BaseController in libraries/src/MVC/Controller/BaseController.php
 - HtmlView in libraries/src/MVC/View/HtmlView.php (for displaying web pages)
@@ -15,27 +17,27 @@ In practical terms, the lowest level classes you would be likely to use are:
 
 In general, using these base classes is a good option if your component is displaying a single item on a site page. 
 
-## BaseController
+### BaseController
 The functionality within BaseController includes: 
 - the `execute()` method described above, which runs the appropriate Controller function, based on the *task* parameter's `<method>` part (which is passed to it).
 - functions for determining the appropriate View and Model classes to use (based on the setting of the view parameter within the HTTP request), and getting the MVCFactory class to create them
 - a default `display()` method, which gets instances of the View and Model classes (including providing the View instance with a link to the Model instance), and then calls the `display()` method of the View class.
 
-## HtmlView
+### HtmlView
 The functionality within HtmlView includes: 
 - a default `display()` method, which runs the tmpl file
 - code for finding the tmpl file, taking into account a layout override which may have been put into the template folder structure
 - code for setting the model instance, and subsequently retrieving it
 
-## BaseDatabaseModel
+### BaseDatabaseModel
 The functionality within BaseDatabaseModel includes: 
 - code for getting an instance of the Table class (via the MVCFactory class)
 - base code for creating a model "state". This feature is useful if the component and/or several modules shown on the web page all use the same base data. In this case they may share the same Model instance and the model "state" acts like a container for sharing the values of items across the component and modules.
 
-# Higher-level Controller Classes
+## Higher-level Controller Classes
 There are 2 higher-level controller classes, each of which inherit from BaseController. 
 
-## AdminController 
+### AdminController 
 AdminController contains methods which handle the types of operations that can be performed on multiple items, for example:
 
 - delete
@@ -49,7 +51,7 @@ The name AdminController suggests that this controller is to be used only on the
 
 Note however that it doesn't support the operations enabled by the Batch button on e.g. the Content/Articles page; these POST requests are handled by the FormController.
 
-## FormController
+### FormController
 FormController contains methods which are associated with editing an individual item 
 
 - handling a request to edit an item – which involves checking that the user is allowed to edit the item and that it isn't already checked out, and if these checks pass then the item is checked out (if that component has enabled checkout) and a redirect is issued to display the edit form
@@ -60,14 +62,14 @@ FormController contains methods which are associated with editing an individual 
 
 The FormController is thus well suited to Actions 3 and 5 shown in the diagrams above in the [Post/Request/Get pattern](post-redirect-get.md) section.
 
-# Higher-level View Classes
+## Higher-level View Classes
 Apart from the CategoryFeedView, which is used for generating a [feed](https://docs.joomla.org/J3.x:Developing_an_MVC_Component/Adding_a_Feed), there are two higher level View classes in common usage:
 - CategoryView – for displaying a category and its children
 - CategoriesView – for displaying all the categories at a certain level in the category hierarchy, and the number of items associated with each category
 
 The two classes ListView and FormView seem to be aimed at functionality for displaying a list of records (like the `com_content` administrator View\Articles\HtmlView) and a form for editing a record (like the `com_content` administrator View\Article\HtmlView). However, at time of writing (Joomla 5 alpha has recently appeared), they aren't used by any of the Joomla components, so I wouldn't recommend using them, at least not yet.
 
-## Higher-level Model Classes
+### Higher-level Model Classes
 The diagram shows the inheritance tree of the Joomla library MVC models. 
 ![Model Class Hierarchy](_assets/model-hierarchy.jpg "Model Class Hierarchy")
 
@@ -87,32 +89,32 @@ Something to be aware of if you are using the same model across the "edit item" 
 
 When you're using the model because you're handling a POST (i.e. cases 3 and 5 in the diagram) then any effort expended in preparing the data for a web page is going to be wasted. (In fact, in the FormController `getModel()` method call, the parameter `$config` is set to `array('ignore_request' => true)` by default, which results in the model's `populateState` method not being run, to save this wasted effort.) 
 
-# Summary
+## Summary
 As we've seen, Joomla has rich functionality in higher level Controller and Model classes which can greatly simplify your code (all of which can be used on both the front end and back end). 
 
 The choice of which controller and model classes to extend is easier on the back end, because you just follow the pattern of the Joomla core components.
 
 For the front end here's a rough guide to choosing the most appropriate Controller and Model classes to extend; in each case you're using the standard HtmlView as base View class to extend.
 
-## Simple Display
+### Simple Display
 Simply displaying a record or a set of records, without providing the ability to change anything
 - Controller extends BaseController
 - Model extends BaseDatabaseModel or (particularly if you're sharing a model between a component and modules) ItemModel if it's a single record, ListModel if it's multiple records.
 
-## Displaying records, plus operations on selected records
+### Displaying records, plus operations on selected records
 Displaying a form with multiple records (but the form isn't defined in an XML file), including the providing the ability to select several records and apply some sort of operation to them (eg delete, publish):
 - Controller extends BaseController
 - Model extends ListModel – except if you're using the same model for displaying the form and handling the updates, in which case use AdminModel
 
-## Handling the HTTP POSTs from the above
+### Handling the HTTP POSTs from the above
 - Controller extends AdminController
 - Model extends AdminModel
 
-## Editing a record
+### Editing a record
 Displaying a form with a single record, where the form is defined in an XML file, and allowing the user to edit it, or a blank record and allowing the user to create a record:
 - Controller extends BaseController
 - Model extends FormModel – except if you're using the same model for displaying the form and handling the updates (as is usually the case), in which case use AdminModel
 
-## Handling the HTTP POSTs from the above
+### Handling the HTTP POSTs from the above
 - Controller extends FormController
 - Model extends AdminModel

--- a/versioned_docs/version-5.0/building-extensions/components/mvc/mvc-factory.md
+++ b/versioned_docs/version-5.0/building-extensions/components/mvc/mvc-factory.md
@@ -2,7 +2,10 @@
 title: The MVC Factory Class
 sidebar_position: 2
 ---
-# MVC Factory Overview
+
+MVC Factory Overview
+====================
+
 The MVC Factory class is used within Joomla to create instances of component Controller, View, Model and Table classes. 
 
 Each component has its own MVCFactory class instance, which is instantiated passing in that component's [namespace prefix](../../../general-concepts/namespaces/defining-your-namespace.md). 
@@ -27,10 +30,10 @@ $model = $this->getModel('example', 'administrator');
 ```
 Note that if your component is running in the front end (site) you can still use the administrator model, and if it's running in the back end (administrator) you can still use the site model. There is no restriction. 
 
-# Creating the MVCFactory class instance
+## Creating the MVCFactory class instance
 Your component's MVCFactory is created by defining it as a dependendency in your services/provider.php file, as described in [Dependency Injection](../../../general-concepts/dependency-injection/index.md), but you don't have to understand all the intricacies of Joomla Dependency Injection to use it effectively.
 
-# Creating your Controller class instance
+## Creating your Controller class instance
 
 As described in [Extension and Dispatcher Classes](../../../general-concepts/extension-and-dispatcher/index.md), your Controller class is instantiated within the `dispatch` function of the ComponentDispatcher class. It has an instance variable pointing to the MVCFactory class and will call:
 ```php
@@ -46,7 +49,7 @@ In this diagram (and in the next):
 - the solid black lines represent method calls
 - the thick solid red lines represent where a Factory class instantiates a class
 
-# Creating your View, Model and Table class instances
+## Creating your View, Model and Table class instances
 
 ![Instantiating View, Model, Table](_assets/mvc-factory.jpg "Instantiating View, Model, Table")
 
@@ -59,7 +62,7 @@ The View can also get the Model via a `getModel` call, but only if the Controlle
 $view->setModel($model);
 ```
 
-# Default names for View, Model and Table classes
+## Default names for View, Model and Table classes
 While the name for the Controller is taken from the *task* parameter, the default names for the View, Model and Table classes are taken from the *view* parameter. These default classes are what will be instantiated if you just call `getView()`, `getModel()` and `getTable()` without any parameters. 
 
 So, for example, the names of the classes created for a request with URL query "?option=com_example&view=viewname" and no *task* parameter will be:
@@ -68,7 +71,7 @@ So, for example, the names of the classes created for a request with URL query "
 - `<namespace>\Model\ViewnameModel`
 - `<namespace>\Table\ViewnameTable`
 
-# Summary
+## Summary
 We've covered a fair bit of background in this section, to give you an understanding of why things work, but it's all to make it easy for you in your MVC classes.
 
 In your Controller, you can create the View and the Model, and give the View a reference to the Model:
@@ -100,7 +103,7 @@ $table = $this->getTable();           // if your Table class matches the view= p
 $table = $this->getTable('example');  // to get the ExampleTable class
 ```
 
-# Issues
+## Issues
 A key reason for the introduction of the MVCFactory class was to remove the use of the `static::getInstance()` calls to obtain an instance of one of the MVC classes. However, you may find one or two problems with the approach.
 
 For example, when saving a database record in the Table class (eg in `Joomla\CMS\Table\Content::store()`), Joomla obtains another instance of that Table class in order to verify that the alias which is about to be saved is unique. However, when the Table instance is created it isn't passed a pointer to the MVCFactory instance, so it can't create another instance using the MVCFactory's `createTable` function. In Joomla 4 the solution was to use the deprecated `getInstance()` function:

--- a/versioned_docs/version-5.0/building-extensions/components/mvc/mvc-overview.md
+++ b/versioned_docs/version-5.0/building-extensions/components/mvc/mvc-overview.md
@@ -2,14 +2,18 @@
 title: MVC Overview
 sidebar_position: 1
 ---
-# MVC Overview
+MVC Overview
+============
+
 The diagram below depicts the MVC pattern as it's used in Joomla. This applies to both the admin back end and the site front end.
 
 ![MVC Overview](_assets/mvc-overview.jpg "MVC Overview")
 
+## Basic Elements
+
 In this section we will cover the 4 types of classes shown in the diagram. In your component you're likely to have several Controller, View and Model classes, and (if your component uses its own table or tables in the database) one Table class for each database table your component has. 
 
-## Controller
+### Controller
 Your Controller code is run whenever there's an incoming HTTP request which is routed to your component. The controller is responsible for analysing the user's request, checking that the user is allowed to perform that action and determining how to satisfy the request. The latter could involve:
 
 - determining which Model (or Models) will be needed to satisfy the request, and creating an instance of that Model
@@ -17,7 +21,7 @@ Your Controller code is run whenever there's an incoming HTTP request which is r
 - determining which View should be used to present the web page to the user, and creating an instance of that View or
 - if instead the user should receive a redirect to another URL, then determining that redirect URL.
 
-## View
+### View
 The MVC View functionality is split into 2 files
 
 1. A View class file, which is usually just known as the View, and after this we'll just call it the View
@@ -35,19 +39,19 @@ This means that if the View holds the response data in, for example, `$this->ite
 
 Separating the View and tmpl like this enables another level of flexibility, as you can easily set up a layout override to output the View data using your own preferred HTML. 
 
-## Model
+### Model
 The Model encapsulates the data used by the component. In most cases this data will come from a database, either the Joomla database, or some external database, but it is also possible for the Model to obtain data from other sources, such as via a web services API running on another server. The Model is also responsible for updating the database where appropriate. The purpose of the Model is to isolate the Controller and View from the details of how data is obtained or amended.
 
 If the component is displaying a form which is defined in XML using the Joomla Form approach, the Model handles the setting-up and configuration of the `Form` instance, ready for the tmpl to output fields using `$form->renderField()` etc. 
 
-## Table
+### Table
 If your extension has one or more database tables, then you should have a Table class for each database table. Your Table class will inherit from the Joomla library Table class, which provides CRUD (Create / Read / Update / Delete) access to the underlying database table.
 
 The Table class provides access to individual records only, so it would be used by the Model if the requirement was a CRUD operation on an individual record, eg to create or update a record in the database.
 
 If instead it's required to access several records in the database table, then the Model would access the database directly, rather than using the Table class.
 
-# The HTTP Request *task* Parameter
+## The HTTP Request *task* Parameter
 Joomla uses the HTTP Request *task* parameter to determine which controller should be used. The *task* parameter can be sent in an HTTP GET or an HTTP POST - Joomla doesn't mind which - and it's just an ordinary HTTP parameter, nothing special. 
 
 The *task* parameter is of the form `<controllerType>.<method>`. The first part identifies the particular Controller class to use, and the second part identifies that class's instance method to call.
@@ -58,7 +62,7 @@ If the task parameter is not set at all then the `display()` method in the Displ
 
 We'll look at some examples later on.
 
-# Your MVC within Joomla
+## Your MVC within Joomla
 Of course, your component's MVC code runs within the context of Joomla's library code, really like the meat in a sandwich. When Joomla determines that it should run your component, then it obtains your component's Extension and Dispatcher classes, and it's the `dispatch()` function of the Joomla ComponentDispatcher class which actually analyses the *task* parameter to determine which of your Controller classes to instantiate, as described in [Extension and Dispatcher classes](../../../general-concepts/extension-and-dispatcher/index.md). Then `dispatch()` calls your component's `execute()` method, passing the `<method>` part of the *task* parameter. Assuming your component has Joomla\CMS\MVC\Controller\BaseController in its inheritance chain, then this will result (in the normal case) in your Controller's `method` function being called. 
 
 After the `execute()` method completes the `dispatch()` method will call the Controller's `redirect()` method - we'll see the significance of this later. 

--- a/versioned_docs/version-5.0/building-extensions/components/mvc/post-redirect-get.md
+++ b/versioned_docs/version-5.0/building-extensions/components/mvc/post-redirect-get.md
@@ -2,22 +2,25 @@
 title: Post-Request-Get Pattern
 sidebar_position: 3
 ---
-# Post-Request-Get Pattern
+
+Post-Request-Get Pattern
+========================
+
 Joomla follows the [Post/Redirect/Get pattern](https://en.wikipedia.org/wiki/Post/Redirect/Get), which means that when a user submits a form in an HTTP POST, then rather than Joomla responding to the POST with an HTML page, it redirects to another page which the browser will access with an HTTP GET. In this section we'll look at a couple of examples of this, and see how it aligns with the use of the *task* parameter, and later with the Joomla library MVC classes.
 
 Although Joomla uses the Post-Request-Get Pattern extensively, this doesn't mean that you have to use it everywhere in your own component. For example, if your component has a front-end form which is used to submit an order, then it may make perfect sense to provide the order confirmation text as the HTTP response to the HTTP POST of the order submission. 
 
-# Example 1 Publish Articles
+## Example 1 Publish Articles
 The diagram shows the steps associated within publishing articles on the Joomla back-end. You'll probably find it helpful to perform these operations on your own Joomla instance, and use your browser's devtools to examine the HTTP requests and responses. 
 
 ![Publishing Articles](_assets/post-request-get1.jpg "Publishing Articles")
 
-## Action 1
+### Action 1
 The administrator clicks on Content / Articles to display the list of articles. This is simply an HTTP GET request to the `com_content` administrator webpage with the `view` parameter set to `articles`. (If SEF URLs are being used, then it's the Joomla Router which will set up the `view` parameter, based on parsing the incoming URL). The *task* parameter is not set in this HTTP request, and so the `com_content` DisplayController is instantiated and the `display()` method called. Based on the `view` parameter, the default View class is Joomla\Component\Content\Administrator\View\\**Articles**\HtmlView, and the default Model is Joomla\Component\Content\Administrator\Model\\**Articles**Model.
 
 A key thing to note is that this view displays various buttons at the top of the form. When you select one or more articles, then these buttons become visible in the Actions button drop-down at the top of the page. It is these buttons which trigger an HTTP POST to the server, and embedded within the buttons is what the *task* parameter gets set to within that POST request.  
 
-## Action 2
+### Action 2
 The administrator selects a number of articles and then presses the Publish button. At this point it's worth switching on your browser's devtools, and examining the messages. You'll see that pressing Publish triggers:
 - an HTTP POST request to the server with
 - the *task* parameter set to "articles.publish"
@@ -85,28 +88,28 @@ to get the `<method>` part of the *task* parameter, in order to code the differe
 
 Secondly, did you notice how much of the code to handle the publish operation was actually within the `com_content` code? Very little! Practically all the code was within the Joomla library MVC classes. Making judicious choices in how you name your component's fields and how your component's MVC classes extend the Joomla library classes can make it easy for you to include functionality with very little coding effort. We'll look at the Joomla library MVC classes in more detail in the next section.
 
-## Action 1 again
+### Action 1 again
 The URL redirect at the end of Action 2 results in the display of the list of articles again. However, this time the user will see a message like "2 articles published" at the top of the form. 
 
 There may be 2 administrators logged on simultaneously, and both displaying the list of articles around the same time. How does Joomla know which administrator should be shown the "2 articles published" message? The answer is that it uses cookies. When the administrator's browsers sends the HTTP GET request to display the list of articles it sends in the request all the cookies which the server previously sent to it. One of these will be used by the Joomla Session functionality as an index to the Session data which is stored for that user. The `enqueueMessage` function described above stores a message within this session data, and when Joomla processes the next HTTP request it will see that there's a message stored there and will output it to the page.
 
 You can see what's stored in your session data by switching on Joomla Debug in the global configuration, and then clicking on the little Joomla symbol at the bottom left of each web page. However you won't see any enqueued messages because when Joomla outputs an enqueued message it removes it from the session, so that it isn't displayed again on the next HTTP request. 
 
-# Example 2 Edit Article
+## Example 2 Edit Article
 ![Editing Articles](_assets/post-request-get2.jpg "Editing Articles")
 
-## Action 1
+### Action 1
 This is the same as above, displaying the list of articles.
 
-## Action 3
+### Action 3
 The administrator clicks on an article to edit it. If you switch off Search Engine Friendly (SEF) URLs in your Global Configuration / Site parameters, then you'll see that the link behind each article title is something like `http://yourdomain.org/administrator/index.php?option=com_content&task=article.edit&id=1`. So the HTTP GET request sent to the server will have *task* set to "article.edit", and this will result in the `com_content` ArticleController being instantiated, and its `edit()` function being called.
 
 Similar to what we found previously, there's no `edit` function within ArticleController.php, so what is run is the `edit` function in the class it extends, namely Joomla\CMS\MVC\Controller\FormController in libraries/src/MVC/Controller/FormController.php. It basically checks that the user is allowed to perform this operation, and if so, checks the content record out (by setting the `checked_out` and `checked_out_time` columns in the article record in the database), and sets up a redirect to display the article edit form.
 
-## Action 4
+### Action 4
 The redirect results in an HTTP GET to a URL like http://yourdomain.org/administrator/index.php?option=com_content&view=article&layout=edit&id=1. The *task* parameter is not set so this will be handled by the `com_content` DisplayController, in the `display()` function. It will use the `com_content` Article View class in src/View/Article/HtmlView.php, and the tmpl file used will be tmpl/article/edit.php (from the `layout` parameter). This displays the form for editing a single article.
 
-## Action 5
+### Action 5
 When the administrator clicks on `Save & Close` then this will result in an HTTP POST to the server, with the article's field values, and *task* set to "article.save". This will be routed to the `com_content` ArticleController, and its `save()` function. Once again the `save` function is absent, so it drops back to using the `save` function in the class which ArticleController extends, namely Joomla\CMS\MVC\Controller\FormController in libraries/src/MVC/Controller/FormController.php. This function does the following (in its 'happy path'):
 - checks the user is allowed to perform the operation
 - validates the data (ie the submitted article fields) 
@@ -115,6 +118,6 @@ When the administrator clicks on `Save & Close` then this will result in an HTTP
 - enqueues a confirmation message that the save succeeded
 - sets up a redirect back to the form showing the list of articles
 
-## Action 1 again
+### Action 1 again
 As before, this displays the list of articles, plus the enqueued message.
 

--- a/versioned_docs/version-5.0/building-extensions/index.md
+++ b/versioned_docs/version-5.0/building-extensions/index.md
@@ -3,13 +3,14 @@ sidebar_position: 5
 ---
 Build Extensions
 ================
+
 Joomla is a rich featured content management system, but if you're building a website with Joomla and you need extra features which aren't available by default, then you can easily extend it with extensions. There are five common types of extensions for Joomla: Components, Modules, Plugins, Templates, and Languages. There are three others: Packages, Files and Libraries. Each of these extensions handle specific functionality (many built-in features of Joomla are implemented using extensions).
 
 The difference between Joomla components, modules, plugins and templates can be initially confusing. If you're new to Joomla then you may find it useful to watch the video [How Joomla Works - a guide for extension developers](https://youtu.be/JKnq47Yhtvs), which describes how these 4 types of extension fit into the generation of a Joomla web page. Their output is also highlighted in different colours in the diagram below. 
 
 ![Screenshot showing extension types](./_assets/screenshot-extension-types.jpg)
 
-# Components
+## Components
 [Components](./components/index.md) provide the central part of a web page on a Joomla site; each site web page displays the output from one component. They can be thought of as mini applications. Most components have two parts: a site part and an administrator part. For example, `com_content` is the component which handles articles; on the site front-end `com_content` displays articles to website visitors and on the back-end `com_content` provides the functionality for administrators to edit articles. 
 
 In general, components manage the data of the Joomla instance and provide functionality for creating, editing, removing and displaying the data. Often the data management aspects are handled in the administrator back-end and the site front-end simply displays the data, but this split of responsibility is not mandated, and some components provide front-end functionality for creating/editing/removing data.
@@ -21,7 +22,7 @@ When you navigate to a certain page on a site or perform a certain operation suc
 
 Examples of component functionality available from third party extensions include backup utilities and support for eCommerce. 
 
-# Modules
+## Modules
 [Modules](./modules/index.md) are more lightweight and flexible extensions displayed on a web page. Modules are mostly known as the “boxes” that are arranged around a component, for example: the login module or the breadcrumbs module. Modules are assigned per menu item. So you can decide to show or hide the login module depending on which menu item the user is viewing. 
 
 A module can often be a companion to the component. For example, if your web page displays an article (`com_content` component) then you might have a module (`mod_tags_similar`) in the sidebar which displays links to related articles, or a module which displays an image slider of related photos.
@@ -33,32 +34,32 @@ However, modules do not need to be linked to components, as a matter of fact the
 
 If you're just beginning with Joomla extension development then developing a module is the easiest place to start. 
 
-# Plugins
+## Plugins
 [Plugins](./plugins/index.md) work behind the scenes to modify or enhance the basic Joomla functionality. In the execution of any part of Joomla - be it the core, a module or a component - an event can be triggered. When an event is triggered, plugins which are registered to handle that event execute, and are passed data related to that event. The plugin can then, for example, modify the data and return it to the core Joomla code. For example, a plugin could be used to intercept user-submitted articles and filter out bad words.
 
 - Examples: Content pagenavigation plugin (which generates the Prev and Next links as shown in the screenshot above)
 - Management feature: Admin menu → System → Plugins
 
-# Templates
+## Templates
 A [template](./templates/index.md) is basically the design of your Joomla-powered website. With a template you define the look and feel of your website, primarily based on CSS. Templates have certain fields in which the component (just one) and modules (as many as you like) will be shown. Building a complete Joomla template from scratch is difficult because you have to understand the variety of HTML output by the Joomla components, and the CSS classes which are used within them. However, it is relatively easy to customize the Atum (administrator) and Cassiopeia (site) templates which are shipped with Joomla, particularly as you can use the Joomla child template functionality to simply specify deviations from the parent template. 
 
 - Management feature: Admin menu → System → Templates
 
-# Languages
+## Languages
 Probably the most basic extensions are languages. Languages can be packaged in two ways: either as a core package or as an extension package. In essence, both the core and the extension language package files consist of key/value pairs, which provide the translation of static text strings, assigned within the Joomla source code. These language packs will affect both the front and administrator side of your Joomla instance. Note: these language packs also include an XML meta file which describes the language.
 
 - Management feature: Admin menu → System → Manage / Languages
 
-# Libraries
+## Libraries
 Libraries are standalone PHP snippets that Joomla uses. Note nearly all of Joomla's core code is available as a library within the libraries/src folder. All composer libraries (such as PHPMailer) are installed as a library "vendor" within libraries/vendor. Many of the most popular 3rd party extensions in Joomla use libraries to reuse common functionality across their components. 
 
-# File
+## File
 The File extension type is used to install individual files into a directory of the Joomla instance. There are no examples in Joomla Core of this type and it is the least used type, however it can be used for example to place [custom scripts](./custom-script/index.md) into the Joomla cli directory or to place template overrides into a specific directory. 
 
-# Packages
+## Packages
 Packages are simply a group of any of the above types of extensions. A common use of a package would be to ship a template that also bundles a system plugin. Or a component that also installs a library it uses. In Joomla many language packs install as a package so that the frontend and backend languages can be installed independently. 
 
-# Extension Installation
+## Extension Installation
 There are 4 methods of installing an extension. You can install from the Joomla Extension Directory (Install from Web), upload the zip file of an extension, install from a folder or install from a URL. 
 
 ![Screenshot showing installing an extension](./_assets/screenshot-install-extension.jpg)

--- a/versioned_docs/version-5.0/building-extensions/modules/module-development-tutorial/step10_abstract_module_dispatcher.md
+++ b/versioned_docs/version-5.0/building-extensions/modules/module-development-tutorial/step10_abstract_module_dispatcher.md
@@ -140,7 +140,7 @@ If you have more complex requirements then you may need to override more functio
 ## Updated Manifest File
 
 ```xml title="mod_hello/mod_hello.xml"
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <extension type="module" client="site" method="upgrade">
     <name>MOD_HELLO_NAME</name>
     <!-- highlight-next-line -->

--- a/versioned_docs/version-5.0/building-extensions/modules/module-development-tutorial/step11_update_server.md
+++ b/versioned_docs/version-5.0/building-extensions/modules/module-development-tutorial/step11_update_server.md
@@ -30,7 +30,7 @@ To associate mod_hello with an update server you need to add the following lines
 Your updated manifest file is thus:
 
 ```xml title="mod_hello/mod_hello.xml"
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <extension type="module" client="site" method="upgrade">
     <name>MOD_HELLO_NAME</name>
     <!-- highlight-next=line -->

--- a/versioned_docs/version-5.0/building-extensions/modules/module-development-tutorial/step5-config.md
+++ b/versioned_docs/version-5.0/building-extensions/modules/module-development-tutorial/step5-config.md
@@ -21,7 +21,7 @@ The source code is available at [mod_hello step 5](https://github.com/joomla/man
 The configuration is implemented by adding a section to the manifest file:
 
 ```xml title="mod_hello/mod_hello.xml"
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <extension type="module" client="site" method="upgrade">
     <name>MOD_HELLO_NAME</name>
     <!-- highlight-next-line -->
@@ -105,7 +105,7 @@ $params = Registry($this->module->params);
 $h = $params->get('header', 'default');
 ```
 
-See the [Registry API documentation](https://api.joomla.org/framework-3/classes/Joomla-Registry-Registry.html) for details. 
+See the [Registry API documentation](framework-api://classes/Joomla-Registry-Registry.html) for details. 
 
 ### Application Parameter
 

--- a/versioned_docs/version-5.1/building-extensions/components/mvc/library-mvc.md
+++ b/versioned_docs/version-5.1/building-extensions/components/mvc/library-mvc.md
@@ -2,10 +2,12 @@
 title: Library MVC Classes
 sidebar_position: 4
 ---
-# Joomla Library MVC Classes
+Joomla Library MVC Classes
+==========================
+
 Joomla provides several Controller, View and Model library classes, and this section gives an overview of these, and explains when your own component should use each class. However, it doesn't attempt to provide a full description of each class's functionality. The classes can be found in libraries/src/MVC.
 
-# Base MVC Classes
+## Base MVC Classes
 In practical terms, the lowest level classes you would be likely to use are:
 - BaseController in libraries/src/MVC/Controller/BaseController.php
 - HtmlView in libraries/src/MVC/View/HtmlView.php (for displaying web pages)
@@ -15,27 +17,27 @@ In practical terms, the lowest level classes you would be likely to use are:
 
 In general, using these base classes is a good option if your component is displaying a single item on a site page. 
 
-## BaseController
+### BaseController
 The functionality within BaseController includes: 
 - the `execute()` method described above, which runs the appropriate Controller function, based on the *task* parameter's `<method>` part (which is passed to it).
 - functions for determining the appropriate View and Model classes to use (based on the setting of the view parameter within the HTTP request), and getting the MVCFactory class to create them
 - a default `display()` method, which gets instances of the View and Model classes (including providing the View instance with a link to the Model instance), and then calls the `display()` method of the View class.
 
-## HtmlView
+### HtmlView
 The functionality within HtmlView includes: 
 - a default `display()` method, which runs the tmpl file
 - code for finding the tmpl file, taking into account a layout override which may have been put into the template folder structure
 - code for setting the model instance, and subsequently retrieving it
 
-## BaseDatabaseModel
+### BaseDatabaseModel
 The functionality within BaseDatabaseModel includes: 
 - code for getting an instance of the Table class (via the MVCFactory class)
 - base code for creating a model "state". This feature is useful if the component and/or several modules shown on the web page all use the same base data. In this case they may share the same Model instance and the model "state" acts like a container for sharing the values of items across the component and modules.
 
-# Higher-level Controller Classes
+## Higher-level Controller Classes
 There are 2 higher-level controller classes, each of which inherit from BaseController. 
 
-## AdminController 
+### AdminController 
 AdminController contains methods which handle the types of operations that can be performed on multiple items, for example:
 
 - delete
@@ -49,7 +51,7 @@ The name AdminController suggests that this controller is to be used only on the
 
 Note however that it doesn't support the operations enabled by the Batch button on e.g. the Content/Articles page; these POST requests are handled by the FormController.
 
-## FormController
+### FormController
 FormController contains methods which are associated with editing an individual item 
 
 - handling a request to edit an item – which involves checking that the user is allowed to edit the item and that it isn't already checked out, and if these checks pass then the item is checked out (if that component has enabled checkout) and a redirect is issued to display the edit form
@@ -60,14 +62,14 @@ FormController contains methods which are associated with editing an individual 
 
 The FormController is thus well suited to Actions 3 and 5 shown in the diagrams above in the [Post/Request/Get pattern](post-redirect-get.md) section.
 
-# Higher-level View Classes
+## Higher-level View Classes
 Apart from the CategoryFeedView, which is used for generating a [feed](https://docs.joomla.org/J3.x:Developing_an_MVC_Component/Adding_a_Feed), there are two higher level View classes in common usage:
 - CategoryView – for displaying a category and its children
 - CategoriesView – for displaying all the categories at a certain level in the category hierarchy, and the number of items associated with each category
 
 The two classes ListView and FormView seem to be aimed at functionality for displaying a list of records (like the `com_content` administrator View\Articles\HtmlView) and a form for editing a record (like the `com_content` administrator View\Article\HtmlView). However, at time of writing (Joomla 5 alpha has recently appeared), they aren't used by any of the Joomla components, so I wouldn't recommend using them, at least not yet.
 
-## Higher-level Model Classes
+### Higher-level Model Classes
 The diagram shows the inheritance tree of the Joomla library MVC models. 
 ![Model Class Hierarchy](_assets/model-hierarchy.jpg "Model Class Hierarchy")
 
@@ -87,32 +89,32 @@ Something to be aware of if you are using the same model across the "edit item" 
 
 When you're using the model because you're handling a POST (i.e. cases 3 and 5 in the diagram) then any effort expended in preparing the data for a web page is going to be wasted. (In fact, in the FormController `getModel()` method call, the parameter `$config` is set to `array('ignore_request' => true)` by default, which results in the model's `populateState` method not being run, to save this wasted effort.) 
 
-# Summary
+## Summary
 As we've seen, Joomla has rich functionality in higher level Controller and Model classes which can greatly simplify your code (all of which can be used on both the front end and back end). 
 
 The choice of which controller and model classes to extend is easier on the back end, because you just follow the pattern of the Joomla core components.
 
 For the front end here's a rough guide to choosing the most appropriate Controller and Model classes to extend; in each case you're using the standard HtmlView as base View class to extend.
 
-## Simple Display
+### Simple Display
 Simply displaying a record or a set of records, without providing the ability to change anything
 - Controller extends BaseController
 - Model extends BaseDatabaseModel or (particularly if you're sharing a model between a component and modules) ItemModel if it's a single record, ListModel if it's multiple records.
 
-## Displaying records, plus operations on selected records
+### Displaying records, plus operations on selected records
 Displaying a form with multiple records (but the form isn't defined in an XML file), including the providing the ability to select several records and apply some sort of operation to them (eg delete, publish):
 - Controller extends BaseController
 - Model extends ListModel – except if you're using the same model for displaying the form and handling the updates, in which case use AdminModel
 
-## Handling the HTTP POSTs from the above
+### Handling the HTTP POSTs from the above
 - Controller extends AdminController
 - Model extends AdminModel
 
-## Editing a record
+### Editing a record
 Displaying a form with a single record, where the form is defined in an XML file, and allowing the user to edit it, or a blank record and allowing the user to create a record:
 - Controller extends BaseController
 - Model extends FormModel – except if you're using the same model for displaying the form and handling the updates (as is usually the case), in which case use AdminModel
 
-## Handling the HTTP POSTs from the above
+### Handling the HTTP POSTs from the above
 - Controller extends FormController
 - Model extends AdminModel

--- a/versioned_docs/version-5.1/building-extensions/components/mvc/mvc-factory.md
+++ b/versioned_docs/version-5.1/building-extensions/components/mvc/mvc-factory.md
@@ -2,7 +2,10 @@
 title: The MVC Factory Class
 sidebar_position: 2
 ---
-# MVC Factory Overview
+
+MVC Factory Overview
+====================
+
 The MVC Factory class is used within Joomla to create instances of component Controller, View, Model and Table classes. 
 
 Each component has its own MVCFactory class instance, which is instantiated passing in that component's [namespace prefix](../../../general-concepts/namespaces/defining-your-namespace.md). 
@@ -27,10 +30,10 @@ $model = $this->getModel('example', 'administrator');
 ```
 Note that if your component is running in the front end (site) you can still use the administrator model, and if it's running in the back end (administrator) you can still use the site model. There is no restriction. 
 
-# Creating the MVCFactory class instance
+## Creating the MVCFactory class instance
 Your component's MVCFactory is created by defining it as a dependendency in your services/provider.php file, as described in [Dependency Injection](../../../general-concepts/dependency-injection/index.md), but you don't have to understand all the intricacies of Joomla Dependency Injection to use it effectively.
 
-# Creating your Controller class instance
+## Creating your Controller class instance
 
 As described in [Extension and Dispatcher Classes](../../../general-concepts/extension-and-dispatcher/index.md), your Controller class is instantiated within the `dispatch` function of the ComponentDispatcher class. It has an instance variable pointing to the MVCFactory class and will call:
 ```php
@@ -46,7 +49,7 @@ In this diagram (and in the next):
 - the solid black lines represent method calls
 - the thick solid red lines represent where a Factory class instantiates a class
 
-# Creating your View, Model and Table class instances
+## Creating your View, Model and Table class instances
 
 ![Instantiating View, Model, Table](_assets/mvc-factory.jpg "Instantiating View, Model, Table")
 
@@ -59,7 +62,7 @@ The View can also get the Model via a `getModel` call, but only if the Controlle
 $view->setModel($model);
 ```
 
-# Default names for View, Model and Table classes
+## Default names for View, Model and Table classes
 While the name for the Controller is taken from the *task* parameter, the default names for the View, Model and Table classes are taken from the *view* parameter. These default classes are what will be instantiated if you just call `getView()`, `getModel()` and `getTable()` without any parameters. 
 
 So, for example, the names of the classes created for a request with URL query "?option=com_example&view=viewname" and no *task* parameter will be:
@@ -68,7 +71,7 @@ So, for example, the names of the classes created for a request with URL query "
 - `<namespace>\Model\ViewnameModel`
 - `<namespace>\Table\ViewnameTable`
 
-# Summary
+## Summary
 We've covered a fair bit of background in this section, to give you an understanding of why things work, but it's all to make it easy for you in your MVC classes.
 
 In your Controller, you can create the View and the Model, and give the View a reference to the Model:
@@ -100,7 +103,7 @@ $table = $this->getTable();           // if your Table class matches the view= p
 $table = $this->getTable('example');  // to get the ExampleTable class
 ```
 
-# Issues
+## Issues
 A key reason for the introduction of the MVCFactory class was to remove the use of the `static::getInstance()` calls to obtain an instance of one of the MVC classes. However, you may find one or two problems with the approach.
 
 For example, when saving a database record in the Table class (eg in `Joomla\CMS\Table\Content::store()`), Joomla obtains another instance of that Table class in order to verify that the alias which is about to be saved is unique. However, when the Table instance is created it isn't passed a pointer to the MVCFactory instance, so it can't create another instance using the MVCFactory's `createTable` function. In Joomla 4 the solution was to use the deprecated `getInstance()` function:

--- a/versioned_docs/version-5.1/building-extensions/components/mvc/mvc-overview.md
+++ b/versioned_docs/version-5.1/building-extensions/components/mvc/mvc-overview.md
@@ -2,14 +2,18 @@
 title: MVC Overview
 sidebar_position: 1
 ---
-# MVC Overview
+MVC Overview
+============
+
 The diagram below depicts the MVC pattern as it's used in Joomla. This applies to both the admin back end and the site front end.
 
 ![MVC Overview](_assets/mvc-overview.jpg "MVC Overview")
 
+## Basic Elements
+
 In this section we will cover the 4 types of classes shown in the diagram. In your component you're likely to have several Controller, View and Model classes, and (if your component uses its own table or tables in the database) one Table class for each database table your component has. 
 
-## Controller
+### Controller
 Your Controller code is run whenever there's an incoming HTTP request which is routed to your component. The controller is responsible for analysing the user's request, checking that the user is allowed to perform that action and determining how to satisfy the request. The latter could involve:
 
 - determining which Model (or Models) will be needed to satisfy the request, and creating an instance of that Model
@@ -17,7 +21,7 @@ Your Controller code is run whenever there's an incoming HTTP request which is r
 - determining which View should be used to present the web page to the user, and creating an instance of that View or
 - if instead the user should receive a redirect to another URL, then determining that redirect URL.
 
-## View
+### View
 The MVC View functionality is split into 2 files
 
 1. A View class file, which is usually just known as the View, and after this we'll just call it the View
@@ -35,19 +39,19 @@ This means that if the View holds the response data in, for example, `$this->ite
 
 Separating the View and tmpl like this enables another level of flexibility, as you can easily set up a layout override to output the View data using your own preferred HTML. 
 
-## Model
+### Model
 The Model encapsulates the data used by the component. In most cases this data will come from a database, either the Joomla database, or some external database, but it is also possible for the Model to obtain data from other sources, such as via a web services API running on another server. The Model is also responsible for updating the database where appropriate. The purpose of the Model is to isolate the Controller and View from the details of how data is obtained or amended.
 
 If the component is displaying a form which is defined in XML using the Joomla Form approach, the Model handles the setting-up and configuration of the `Form` instance, ready for the tmpl to output fields using `$form->renderField()` etc. 
 
-## Table
+### Table
 If your extension has one or more database tables, then you should have a Table class for each database table. Your Table class will inherit from the Joomla library Table class, which provides CRUD (Create / Read / Update / Delete) access to the underlying database table.
 
 The Table class provides access to individual records only, so it would be used by the Model if the requirement was a CRUD operation on an individual record, eg to create or update a record in the database.
 
 If instead it's required to access several records in the database table, then the Model would access the database directly, rather than using the Table class.
 
-# The HTTP Request *task* Parameter
+## The HTTP Request *task* Parameter
 Joomla uses the HTTP Request *task* parameter to determine which controller should be used. The *task* parameter can be sent in an HTTP GET or an HTTP POST - Joomla doesn't mind which - and it's just an ordinary HTTP parameter, nothing special. 
 
 The *task* parameter is of the form `<controllerType>.<method>`. The first part identifies the particular Controller class to use, and the second part identifies that class's instance method to call.
@@ -58,7 +62,7 @@ If the task parameter is not set at all then the `display()` method in the Displ
 
 We'll look at some examples later on.
 
-# Your MVC within Joomla
+## Your MVC within Joomla
 Of course, your component's MVC code runs within the context of Joomla's library code, really like the meat in a sandwich. When Joomla determines that it should run your component, then it obtains your component's Extension and Dispatcher classes, and it's the `dispatch()` function of the Joomla ComponentDispatcher class which actually analyses the *task* parameter to determine which of your Controller classes to instantiate, as described in [Extension and Dispatcher classes](../../../general-concepts/extension-and-dispatcher/index.md). Then `dispatch()` calls your component's `execute()` method, passing the `<method>` part of the *task* parameter. Assuming your component has Joomla\CMS\MVC\Controller\BaseController in its inheritance chain, then this will result (in the normal case) in your Controller's `method` function being called. 
 
 After the `execute()` method completes the `dispatch()` method will call the Controller's `redirect()` method - we'll see the significance of this later. 

--- a/versioned_docs/version-5.1/building-extensions/components/mvc/post-redirect-get.md
+++ b/versioned_docs/version-5.1/building-extensions/components/mvc/post-redirect-get.md
@@ -2,22 +2,25 @@
 title: Post-Request-Get Pattern
 sidebar_position: 3
 ---
-# Post-Request-Get Pattern
+
+Post-Request-Get Pattern
+========================
+
 Joomla follows the [Post/Redirect/Get pattern](https://en.wikipedia.org/wiki/Post/Redirect/Get), which means that when a user submits a form in an HTTP POST, then rather than Joomla responding to the POST with an HTML page, it redirects to another page which the browser will access with an HTTP GET. In this section we'll look at a couple of examples of this, and see how it aligns with the use of the *task* parameter, and later with the Joomla library MVC classes.
 
 Although Joomla uses the Post-Request-Get Pattern extensively, this doesn't mean that you have to use it everywhere in your own component. For example, if your component has a front-end form which is used to submit an order, then it may make perfect sense to provide the order confirmation text as the HTTP response to the HTTP POST of the order submission. 
 
-# Example 1 Publish Articles
+## Example 1 Publish Articles
 The diagram shows the steps associated within publishing articles on the Joomla back-end. You'll probably find it helpful to perform these operations on your own Joomla instance, and use your browser's devtools to examine the HTTP requests and responses. 
 
 ![Publishing Articles](_assets/post-request-get1.jpg "Publishing Articles")
 
-## Action 1
+### Action 1
 The administrator clicks on Content / Articles to display the list of articles. This is simply an HTTP GET request to the `com_content` administrator webpage with the `view` parameter set to `articles`. (If SEF URLs are being used, then it's the Joomla Router which will set up the `view` parameter, based on parsing the incoming URL). The *task* parameter is not set in this HTTP request, and so the `com_content` DisplayController is instantiated and the `display()` method called. Based on the `view` parameter, the default View class is Joomla\Component\Content\Administrator\View\\**Articles**\HtmlView, and the default Model is Joomla\Component\Content\Administrator\Model\\**Articles**Model.
 
 A key thing to note is that this view displays various buttons at the top of the form. When you select one or more articles, then these buttons become visible in the Actions button drop-down at the top of the page. It is these buttons which trigger an HTTP POST to the server, and embedded within the buttons is what the *task* parameter gets set to within that POST request.  
 
-## Action 2
+### Action 2
 The administrator selects a number of articles and then presses the Publish button. At this point it's worth switching on your browser's devtools, and examining the messages. You'll see that pressing Publish triggers:
 - an HTTP POST request to the server with
 - the *task* parameter set to "articles.publish"
@@ -85,28 +88,28 @@ to get the `<method>` part of the *task* parameter, in order to code the differe
 
 Secondly, did you notice how much of the code to handle the publish operation was actually within the `com_content` code? Very little! Practically all the code was within the Joomla library MVC classes. Making judicious choices in how you name your component's fields and how your component's MVC classes extend the Joomla library classes can make it easy for you to include functionality with very little coding effort. We'll look at the Joomla library MVC classes in more detail in the next section.
 
-## Action 1 again
+### Action 1 again
 The URL redirect at the end of Action 2 results in the display of the list of articles again. However, this time the user will see a message like "2 articles published" at the top of the form. 
 
 There may be 2 administrators logged on simultaneously, and both displaying the list of articles around the same time. How does Joomla know which administrator should be shown the "2 articles published" message? The answer is that it uses cookies. When the administrator's browsers sends the HTTP GET request to display the list of articles it sends in the request all the cookies which the server previously sent to it. One of these will be used by the Joomla Session functionality as an index to the Session data which is stored for that user. The `enqueueMessage` function described above stores a message within this session data, and when Joomla processes the next HTTP request it will see that there's a message stored there and will output it to the page.
 
 You can see what's stored in your session data by switching on Joomla Debug in the global configuration, and then clicking on the little Joomla symbol at the bottom left of each web page. However you won't see any enqueued messages because when Joomla outputs an enqueued message it removes it from the session, so that it isn't displayed again on the next HTTP request. 
 
-# Example 2 Edit Article
+## Example 2 Edit Article
 ![Editing Articles](_assets/post-request-get2.jpg "Editing Articles")
 
-## Action 1
+### Action 1
 This is the same as above, displaying the list of articles.
 
-## Action 3
+### Action 3
 The administrator clicks on an article to edit it. If you switch off Search Engine Friendly (SEF) URLs in your Global Configuration / Site parameters, then you'll see that the link behind each article title is something like `http://yourdomain.org/administrator/index.php?option=com_content&task=article.edit&id=1`. So the HTTP GET request sent to the server will have *task* set to "article.edit", and this will result in the `com_content` ArticleController being instantiated, and its `edit()` function being called.
 
 Similar to what we found previously, there's no `edit` function within ArticleController.php, so what is run is the `edit` function in the class it extends, namely Joomla\CMS\MVC\Controller\FormController in libraries/src/MVC/Controller/FormController.php. It basically checks that the user is allowed to perform this operation, and if so, checks the content record out (by setting the `checked_out` and `checked_out_time` columns in the article record in the database), and sets up a redirect to display the article edit form.
 
-## Action 4
+### Action 4
 The redirect results in an HTTP GET to a URL like http://yourdomain.org/administrator/index.php?option=com_content&view=article&layout=edit&id=1. The *task* parameter is not set so this will be handled by the `com_content` DisplayController, in the `display()` function. It will use the `com_content` Article View class in src/View/Article/HtmlView.php, and the tmpl file used will be tmpl/article/edit.php (from the `layout` parameter). This displays the form for editing a single article.
 
-## Action 5
+### Action 5
 When the administrator clicks on `Save & Close` then this will result in an HTTP POST to the server, with the article's field values, and *task* set to "article.save". This will be routed to the `com_content` ArticleController, and its `save()` function. Once again the `save` function is absent, so it drops back to using the `save` function in the class which ArticleController extends, namely Joomla\CMS\MVC\Controller\FormController in libraries/src/MVC/Controller/FormController.php. This function does the following (in its 'happy path'):
 - checks the user is allowed to perform the operation
 - validates the data (ie the submitted article fields) 
@@ -115,6 +118,6 @@ When the administrator clicks on `Save & Close` then this will result in an HTTP
 - enqueues a confirmation message that the save succeeded
 - sets up a redirect back to the form showing the list of articles
 
-## Action 1 again
+### Action 1 again
 As before, this displays the list of articles, plus the enqueued message.
 

--- a/versioned_docs/version-5.1/building-extensions/index.md
+++ b/versioned_docs/version-5.1/building-extensions/index.md
@@ -3,13 +3,14 @@ sidebar_position: 5
 ---
 Build Extensions
 ================
+
 Joomla is a rich featured content management system, but if you're building a website with Joomla and you need extra features which aren't available by default, then you can easily extend it with extensions. There are five common types of extensions for Joomla: Components, Modules, Plugins, Templates, and Languages. There are three others: Packages, Files and Libraries. Each of these extensions handle specific functionality (many built-in features of Joomla are implemented using extensions).
 
 The difference between Joomla components, modules, plugins and templates can be initially confusing. If you're new to Joomla then you may find it useful to watch the video [How Joomla Works - a guide for extension developers](https://youtu.be/JKnq47Yhtvs), which describes how these 4 types of extension fit into the generation of a Joomla web page. Their output is also highlighted in different colours in the diagram below. 
 
 ![Screenshot showing extension types](./_assets/screenshot-extension-types.jpg)
 
-# Components
+## Components
 [Components](./components/index.md) provide the central part of a web page on a Joomla site; each site web page displays the output from one component. They can be thought of as mini applications. Most components have two parts: a site part and an administrator part. For example, `com_content` is the component which handles articles; on the site front-end `com_content` displays articles to website visitors and on the back-end `com_content` provides the functionality for administrators to edit articles. 
 
 In general, components manage the data of the Joomla instance and provide functionality for creating, editing, removing and displaying the data. Often the data management aspects are handled in the administrator back-end and the site front-end simply displays the data, but this split of responsibility is not mandated, and some components provide front-end functionality for creating/editing/removing data.
@@ -21,7 +22,7 @@ When you navigate to a certain page on a site or perform a certain operation suc
 
 Examples of component functionality available from third party extensions include backup utilities and support for eCommerce. 
 
-# Modules
+## Modules
 [Modules](./modules/index.md) are more lightweight and flexible extensions displayed on a web page. Modules are mostly known as the “boxes” that are arranged around a component, for example: the login module or the breadcrumbs module. Modules are assigned per menu item. So you can decide to show or hide the login module depending on which menu item the user is viewing. 
 
 A module can often be a companion to the component. For example, if your web page displays an article (`com_content` component) then you might have a module (`mod_tags_similar`) in the sidebar which displays links to related articles, or a module which displays an image slider of related photos.
@@ -33,32 +34,32 @@ However, modules do not need to be linked to components, as a matter of fact the
 
 If you're just beginning with Joomla extension development then developing a module is the easiest place to start. 
 
-# Plugins
+## Plugins
 [Plugins](./plugins/index.md) work behind the scenes to modify or enhance the basic Joomla functionality. In the execution of any part of Joomla - be it the core, a module or a component - an event can be triggered. When an event is triggered, plugins which are registered to handle that event execute, and are passed data related to that event. The plugin can then, for example, modify the data and return it to the core Joomla code. For example, a plugin could be used to intercept user-submitted articles and filter out bad words.
 
 - Examples: Content pagenavigation plugin (which generates the Prev and Next links as shown in the screenshot above)
 - Management feature: Admin menu → System → Plugins
 
-# Templates
+## Templates
 A [template](./templates/index.md) is basically the design of your Joomla-powered website. With a template you define the look and feel of your website, primarily based on CSS. Templates have certain fields in which the component (just one) and modules (as many as you like) will be shown. Building a complete Joomla template from scratch is difficult because you have to understand the variety of HTML output by the Joomla components, and the CSS classes which are used within them. However, it is relatively easy to customize the Atum (administrator) and Cassiopeia (site) templates which are shipped with Joomla, particularly as you can use the Joomla child template functionality to simply specify deviations from the parent template. 
 
 - Management feature: Admin menu → System → Templates
 
-# Languages
+## Languages
 Probably the most basic extensions are languages. Languages can be packaged in two ways: either as a core package or as an extension package. In essence, both the core and the extension language package files consist of key/value pairs, which provide the translation of static text strings, assigned within the Joomla source code. These language packs will affect both the front and administrator side of your Joomla instance. Note: these language packs also include an XML meta file which describes the language.
 
 - Management feature: Admin menu → System → Manage / Languages
 
-# Libraries
+## Libraries
 Libraries are standalone PHP snippets that Joomla uses. Note nearly all of Joomla's core code is available as a library within the libraries/src folder. All composer libraries (such as PHPMailer) are installed as a library "vendor" within libraries/vendor. Many of the most popular 3rd party extensions in Joomla use libraries to reuse common functionality across their components. 
 
-# File
+## File
 The File extension type is used to install individual files into a directory of the Joomla instance. There are no examples in Joomla Core of this type and it is the least used type, however it can be used for example to place [custom scripts](./custom-script/index.md) into the Joomla cli directory or to place template overrides into a specific directory. 
 
-# Packages
+## Packages
 Packages are simply a group of any of the above types of extensions. A common use of a package would be to ship a template that also bundles a system plugin. Or a component that also installs a library it uses. In Joomla many language packs install as a package so that the frontend and backend languages can be installed independently. 
 
-# Extension Installation
+## Extension Installation
 There are 4 methods of installing an extension. You can install from the Joomla Extension Directory (Install from Web), upload the zip file of an extension, install from a folder or install from a URL. 
 
 ![Screenshot showing installing an extension](./_assets/screenshot-install-extension.jpg)


### PR DESCRIPTION
copy to other versions the corrections to remove multiple H1 headers, and using UTF instead of utf