### PR TITLE
Removing AbstractView::get()

### DIFF
--- a/migrations/.52-53/new-deprecations.md
+++ b/migrations/.52-53/new-deprecations.md
@@ -1,0 +1,52 @@
+---
+sidebar_position: 2
+---
+
+New deprecations
+================
+
+:::tip[Developer Note]
+  Since this version of Joomla has not been released yet, this page can change anytime.
+:::
+
+All the new deprecations that should be aware of and what you should now be using instead.
+
+## Class deprecations
+
+Planned to be removed in Joomla! 7.0.
+
+### AbstractView::get()
+#### Short version
+`AbstractView::get()` is deprecated and will be removed in 7.0. Use the following code instead:
+```php
+$model = $this->getModel();
+$this->items = $model->getItems();
+```
+#### Explanation
+Joomla and most extensions have extensively been using `Joomla\CMS\MVC\View\AbstractView::get()` in all views. From 5.3 onwards, this method is deprecated and is going to be removed in Joomla 7.0.
+
+This code in the past was used to retrieve data from the model. It was included in the `HtmlView.php` and often looked like this:
+```php
+public function display($tpl = null)
+{
+    $this->items = $this->get('Items');
+    $this->pagination = $this->get('Pagination');
+
+    parent::display($tpl);
+}
+```
+This code in the view called the method `get<FirstArgument>` on the model and returned the result. If the model didn't have such a method, it returned the classes attribute named by the first argument.
+
+The downside of this is an indirection which no IDE and static code analyser can understand and which hides errors. The better solution is to call the model directly, making it easy for an IDE to understand the code. The new code should look like this:
+```php
+public function display($tpl = null)
+{
+    /** @var ArticlesModel $model */
+    $model = $this->getModel();
+    $this->items = $model->getItems();
+    $this->pagination = $model->getPagination();
+
+    parent::display($tpl);
+}
+```
+The first line is a docblock comment, which provides a hint for the IDE for the actual model that is used. The second line will retrieve the model set in the view. If you have more than one model in a view, you can provide it with a parameter to select the right model. The last two lines retrieve the actual data from the model. With the first two lines, IDEs can hint at the available methods in the model and now the returned values from those methods, making it possible to find issues further down the line.


### PR DESCRIPTION
### **User description**
This is the documentation entry for the deprecation in https://github.com/joomla/joomla-cms/pull/44162


___

### **PR Type**
documentation


___

### **Description**
- Added a new documentation entry for deprecations in Joomla version 5.3.
- Deprecated the `AbstractView::get()` method, planned for removal in Joomla 7.0.
- Provided alternative code examples to replace the deprecated method.
- Explained the advantages of the new approach for IDEs and static code analysis.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>new-deprecations.md</strong><dd><code>Document deprecation of AbstractView::get() in Joomla</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/.52-53/new-deprecations.md

<li>Added documentation for new deprecations in Joomla.<br> <li> Detailed the deprecation of <code>AbstractView::get()</code> method.<br> <li> Provided alternative code examples for retrieving model data.<br> <li> Explained the benefits of the new approach for IDEs and static <br>analysis.<br>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/318/files#diff-b84ba55110a899374dbd798195ee1df5edcc1e93ad38974213c1b74019e99999">+52/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information