### PR TITLE
Add deprecate entry for $gmt and $stz in Date class

### DIFF
--- a/migrations/54-60/removed-backward-incompatibility.md
+++ b/migrations/54-60/removed-backward-incompatibility.md
@@ -26,4 +26,9 @@ There should be an explanation of how to mitigate the removals / changes.
 ### UTC is used instead of GMT
 
 - PR: https://github.com/joomla/joomla-cms/pull/43912
-- Description: To unify the code base, all instances do use or fallback to UTC timezone. Make sure that your code doesn't do an check against GMT string.
+- Description: To unify the code base, all instances do use or fallback to UTC timezone. Make sure that your code doesn't do a check against GMT string.
+
+### Removed legacy b/c code in \Joomla\CMS\Date\Date Class
+
+- PR: https://github.com/joomla/joomla-cms/pull/43959
+- Description: Removed Date::$gmt and Date::$stz variables and related code. If you extend the \Joomla\CMS\Date\Date class make sure not to depend on them any longer.


### PR DESCRIPTION
### **User description**
See https://github.com/joomla/joomla-cms/pull/43959


___

### **PR Type**
documentation, enhancement


___

### **Description**
- Corrected a typo in the existing documentation regarding checks against the GMT string.
- Added documentation for the removal of legacy backward compatibility code in the `\Joomla\CMS\Date\Date` class.
- Noted the deprecation of `Date::$gmt` and `Date::$stz` variables and advised against their use in extended classes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>removed-backward-incompatibility.md</strong><dd><code>Document deprecation of $gmt and $stz in Date class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/54-60/removed-backward-incompatibility.md

<li>Corrected a typo in the description regarding GMT string checks.<br> <li> Added a new section about the removal of legacy code in the <br><code>\Joomla\CMS\Date\Date</code> class.<br> <li> Documented the deprecation of <code>Date::$gmt</code> and <code>Date::$stz</code> variables.<br>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/321/files#diff-1b9f27ae2f64c35bc2cdba1c2988613e48b706934385a2e51f36e0e1bd2d23b2">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information