### PR TITLE
small typo in 42-43 new-deprecations.md

### DIFF
--- a/migrations/42-43/new-deprecations.md
+++ b/migrations/42-43/new-deprecations.md
@@ -32,7 +32,7 @@ The section above should be moved to the deprecation strategy.
 
 :::
 
-Planned to be removed in Joomla! 6.0 alias added to the combat plugin in 5.0.
+Planned to be removed in Joomla! 6.0 alias added to the compat plugin in 5.0.
 
 * administrator/components/com_banners/helpers/banners.php
 * administrator/components/com_categories/helpers/categories.php

--- a/migrations/42-43/new-deprecations.md
+++ b/migrations/42-43/new-deprecations.md
@@ -23,7 +23,7 @@ for legacy reasons. For example in Joomla 4 component helpers get moved from
 get a namespace `\Joomla\Component\Banners\Administrator\Helper\BannersHelper`.
 
 The class will be aliased in `libraries/classmap.php` or `libraries/extensions.classmap.php`.
-In the next major version all aliases will be moved to the combat plugin. The file will be
+In the next major version all aliases will be moved to the compat plugin. The file will be
 kept till the next major version, in this version file and alias will be removed.
 
 :::caution TODO


### PR DESCRIPTION
### **User description**
I assume, that would be the compat(ibility) plugin, not the combat one :)


___

### **PR Type**
documentation


___

### **Description**
- Corrected a typo in the documentation file `new-deprecations.md`, changing 'combat' to 'compat' to accurately reflect the intended plugin name.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>new-deprecations.md</strong><dd><code>Correct typo in plugin name from 'combat' to 'compat'</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/42-43/new-deprecations.md

<li>Corrected a typo from 'combat' to 'compat'.<br> <li> Clarified the context regarding plugin naming.<br>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/328/files#diff-606245871e8a303a64c698e663024b4a476c05daa952c51fb9596a4e029af29f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information