### PR TITLE
Force to trailing slash and link fixes

### DIFF
--- a/docs/building-extensions/components/component-examples/ajaxdemo.md
+++ b/docs/building-extensions/components/component-examples/ajaxdemo.md
@@ -63,7 +63,7 @@ Path: components/com_ajaxdemo/tmpl/ajaxdemo/default.php
 
 This uses the [Web Asset Manager](../../../general-concepts/web-asset-manager.md) to attach the JavaScript divide.js which initiates the Ajax call.
 
-It passes the root URL of your Joomla instance to the JavaScript code using [passing variables to Javascript](../../../general-concepts/javascript/adding-javascript#passing-variables-to-javascript)
+It passes the root URL of your Joomla instance to the JavaScript code using [passing variables to Javascript](../../../general-concepts/javascript/adding-javascript.md#passing-variables-to-javascript)
 as this makes the job of forming the URLs easier.
 
 Then it outputs the `<form>` html, including the button with the onclick listener to run the divide.js code.

--- a/docs/building-extensions/plugins/basic-content-plugin.md
+++ b/docs/building-extensions/plugins/basic-content-plugin.md
@@ -173,7 +173,7 @@ Ensure that this matches your class in your `src/Extension` directory.
 ## Extension Class
 This is the main code of the plugin. Hopefully the comments in the code explain what is going on.
 
-As explained in [Joomla 4 and 5 changes](./joomla-4-and-5-changes), code which triggers the Events can use a `GenericEvent` or a concrete Event, eg `ContentPrepareEvent`. In both these cases you can get the arguments using
+As explained in [Joomla 4 and 5 changes](./joomla-4-and-5-changes.md), code which triggers the Events can use a `GenericEvent` or a concrete Event, eg `ContentPrepareEvent`. In both these cases you can get the arguments using
 
 ```php
 [$context, $article, $params, $page] = array_values($event->getArguments());

--- a/docs/general-concepts/javascript/ajax.md
+++ b/docs/general-concepts/javascript/ajax.md
@@ -31,7 +31,7 @@ Within your component you should use the [MVC approach](../../building-extension
 and split your functionality into different Controllers, Models and Views.
 
 The default Joomla [Extension/Dispatcher](../extension-and-dispatcher/index.md) code uses the URL 
-[`task` parameter](../../building-extensions/components/mvc/mvc-overview#the-http-request-task-parameter) 
+[`task` parameter](../../building-extensions/components/mvc/mvc-overview.md#the-http-request-task-parameter) 
 to determine the Controller class to instantiate and the method within that Controller to call.
 
 For example, if you set the `task` parameter to "ajax.divide" then the default Dispatcher code will instantiate your AjaxController and call its `divide` instance method.

--- a/docs/general-concepts/javascript/js-library/joomla-dialog.md
+++ b/docs/general-concepts/javascript/js-library/joomla-dialog.md
@@ -3,7 +3,7 @@ Joomla Dialog (popup) script
 
 Joomla Dialog module provides a functionality which allows to display various Dialogs (popup) windows. 
 
-To add Joomla Dialog module to the page use [WebAssetManager](../../web-asset-manager) `$wa->useScript('joomla.dialog')`, 
+To add Joomla Dialog module to the page use [WebAssetManager](../../web-asset-manager.md) `$wa->useScript('joomla.dialog')`, 
 and to enable auto binding of the buttons on the page use `$wa->useScript('joomla.dialog-autocreate')`.
 
 Joomla Dialog allows to display dialogs with following content:

--- a/docs/security/common-vulnerabilities.md
+++ b/docs/security/common-vulnerabilities.md
@@ -25,7 +25,7 @@ With the output template given above, the JS provided by the user will be output
 ### Prevention
 #### Filter/validate the user input
 In the example above, the provided subject should be filtered and/or validated to only allow required characters - and it should disallow characters that are needed to create HTML tags, i.e. the `<` and `>` characters.
-If the user input can contain HTML markup, the markup itself has to be filtered to make sure it only contains safe markup. See [the chapter about input handling](input-handling) for more information.
+If the user input can contain HTML markup, the markup itself has to be filtered to make sure it only contains safe markup. See [the chapter about input handling](input-handling.md) for more information.
 
 #### Escape the output
 Unless user generated markup is specifically needed (i.e. because the user can use a WYSIWYG editor) it's highly recommended to escape each and every snippet of user provided content.
@@ -36,7 +36,7 @@ To escape user content in Joomla, use the ```echo $this->escape($evilString)``` 
 ## SQL injections / SQLi
 A SQL injection attack is a type of vulnerability where an attacker is able to manipulate a SQL query by injecting user controlled content.
 
-Learn more about this attack scenario and the prevention in [the chapter about secure DB queries](secure-db-queries).
+Learn more about this attack scenario and the prevention in [the chapter about secure DB queries](secure-db-queries.md).
 
 ## Unrestricted file uploads
 Uploading user provided files to a webservers is a potentially dangerous task as it exposes multiple attack vectors at once:
@@ -50,4 +50,4 @@ Therefore file uploads must be very carefully implemented. Check the ```canUploa
 CSRF is an attack type where an HTML form on an external, attacker-controlled site is used to perform an attack against a target site. 
 
 ### Prevention
-Learn more about this in the [CSRF chapter](csrf-protection) of this manual.
+Learn more about this in the [CSRF chapter](csrf-protection.md) of this manual.

--- a/docs/security/forms.md
+++ b/docs/security/forms.md
@@ -4,4 +4,4 @@ sidebar_position: 6
 
 Forms & Validations
 ======================
-See the [form validation chapter for further information](../general-concepts/forms/server-side-validation).
+See the [form validation chapter for further information](../general-concepts/forms/server-side-validation.md).

--- a/docs/security/input-handling.md
+++ b/docs/security/input-handling.md
@@ -5,4 +5,4 @@ sidebar_position: 3
 Input Handling
 ======================
 
-See the [Input chapter for further information](../general-concepts/input).
+See the [Input chapter for further information](../general-concepts/input.md).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -62,6 +62,7 @@ const config = {
   organizationName: 'joomla',
   projectName: 'joomla-cms',
   url: 'https://manual.joomla.org',
+  trailingSlash: true,
   baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',

--- a/versioned_docs/version-4.4/building-extensions/components/component-examples/ajaxdemo.md
+++ b/versioned_docs/version-4.4/building-extensions/components/component-examples/ajaxdemo.md
@@ -63,7 +63,7 @@ Path: components/com_ajaxdemo/tmpl/ajaxdemo/default.php
 
 This uses the [Web Asset Manager](../../../general-concepts/web-asset-manager.md) to attach the JavaScript divide.js which initiates the Ajax call.
 
-It passes the root URL of your Joomla instance to the JavaScript code using [passing variables to Javascript](../../../general-concepts/javascript/adding-javascript#passing-variables-to-javascript)
+It passes the root URL of your Joomla instance to the JavaScript code using [passing variables to Javascript](../../../general-concepts/javascript/adding-javascript.md#passing-variables-to-javascript)
 as this makes the job of forming the URLs easier.
 
 Then it outputs the `<form>` html, including the button with the onclick listener to run the divide.js code.

--- a/versioned_docs/version-4.4/building-extensions/plugins/basic-content-plugin.md
+++ b/versioned_docs/version-4.4/building-extensions/plugins/basic-content-plugin.md
@@ -173,7 +173,7 @@ Ensure that this matches your class in your `src/Extension` directory.
 ## Extension Class
 This is the main code of the plugin. Hopefully the comments in the code explain what is going on.
 
-As explained in [Joomla 4 and 5 changes](./joomla-4-and-5-changes), code which triggers the Events can use a `GenericEvent` or a concrete Event, eg `ContentPrepareEvent`. In both these cases you can get the arguments using
+As explained in [Joomla 4 and 5 changes](./joomla-4-and-5-changes.md), code which triggers the Events can use a `GenericEvent` or a concrete Event, eg `ContentPrepareEvent`. In both these cases you can get the arguments using
 
 ```php
 [$context, $article, $params, $page] = array_values($event->getArguments());

--- a/versioned_docs/version-4.4/general-concepts/javascript/ajax.md
+++ b/versioned_docs/version-4.4/general-concepts/javascript/ajax.md
@@ -31,7 +31,7 @@ Within your component you should use the [MVC approach](../../building-extension
 and split your functionality into different Controllers, Models and Views.
 
 The default Joomla [Extension/Dispatcher](../extension-and-dispatcher/index.md) code uses the URL 
-[`task` parameter](../../building-extensions/components/mvc/mvc-overview#the-http-request-task-parameter) 
+[`task` parameter](../../building-extensions/components/mvc/mvc-overview.md#the-http-request-task-parameter) 
 to determine the Controller class to instantiate and the method within that Controller to call.
 
 For example, if you set the `task` parameter to "ajax.divide" then the default Dispatcher code will instantiate your AjaxController and call its `divide` instance method.

--- a/versioned_docs/version-4.4/general-concepts/javascript/js-library/joomla-dialog.md
+++ b/versioned_docs/version-4.4/general-concepts/javascript/js-library/joomla-dialog.md
@@ -3,7 +3,7 @@ Joomla Dialog (popup) script
 
 Joomla Dialog module provides a functionality which allows to display various Dialogs (popup) windows. 
 
-To add Joomla Dialog module to the page use [WebAssetManager](../../web-asset-manager) `$wa->useScript('joomla.dialog')`, 
+To add Joomla Dialog module to the page use [WebAssetManager](../../web-asset-manager.md) `$wa->useScript('joomla.dialog')`, 
 and to enable auto binding of the buttons on the page use `$wa->useScript('joomla.dialog-autocreate')`.
 
 Joomla Dialog allows to display dialogs with following content:

--- a/versioned_docs/version-4.4/security/common-vulnerabilities.md
+++ b/versioned_docs/version-4.4/security/common-vulnerabilities.md
@@ -25,7 +25,7 @@ With the output template given above, the JS provided by the user will be output
 ### Prevention
 #### Filter/validate the user input
 In the example above, the provided subject should be filtered and/or validated to only allow required characters - and it should disallow characters that are needed to create HTML tags, i.e. the `<` and `>` characters.
-If the user input can contain HTML markup, the markup itself has to be filtered to make sure it only contains safe markup. See [the chapter about input handling](input-handling) for more information.
+If the user input can contain HTML markup, the markup itself has to be filtered to make sure it only contains safe markup. See [the chapter about input handling](input-handling.md) for more information.
 
 #### Escape the output
 Unless user generated markup is specifically needed (i.e. because the user can use a WYSIWYG editor) it's highly recommended to escape each and every snippet of user provided content.
@@ -36,7 +36,7 @@ To escape user content in Joomla, use the ```echo $this->escape($evilString)``` 
 ## SQL injections / SQLi
 A SQL injection attack is a type of vulnerability where an attacker is able to manipulate a SQL query by injecting user controlled content.
 
-Learn more about this attack scenario and the prevention in [the chapter about secure DB queries](secure-db-queries).
+Learn more about this attack scenario and the prevention in [the chapter about secure DB queries](secure-db-queries.md).
 
 ## Unrestricted file uploads
 Uploading user provided files to a webservers is a potentially dangerous task as it exposes multiple attack vectors at once:
@@ -50,4 +50,4 @@ Therefore file uploads must be very carefully implemented. Check the ```canUploa
 CSRF is an attack type where an HTML form on an external, attacker-controlled site is used to perform an attack against a target site. 
 
 ### Prevention
-Learn more about this in the [CSRF chapter](csrf-protection) of this manual.
+Learn more about this in the [CSRF chapter](csrf-protection.md) of this manual.

--- a/versioned_docs/version-4.4/security/forms.md
+++ b/versioned_docs/version-4.4/security/forms.md
@@ -4,4 +4,4 @@ sidebar_position: 6
 
 Forms & Validations
 ======================
-See the [form validation chapter for further information](../general-concepts/forms/server-side-validation).
+See the [form validation chapter for further information](../general-concepts/forms/server-side-validation.md).

--- a/versioned_docs/version-4.4/security/input-handling.md
+++ b/versioned_docs/version-4.4/security/input-handling.md
@@ -5,4 +5,4 @@ sidebar_position: 3
 Input Handling
 ======================
 
-See the [Input chapter for further information](../general-concepts/input).
+See the [Input chapter for further information](../general-concepts/input.md).

--- a/versioned_docs/version-5.0/building-extensions/plugins/basic-content-plugin.md
+++ b/versioned_docs/version-5.0/building-extensions/plugins/basic-content-plugin.md
@@ -169,7 +169,7 @@ Ensure that this matches your class in your `src/Extension` directory.
 ## Extension Class
 This is the main code of the plugin. Hopefully the comments in the code explain what is going on.
 
-As explained in [Joomla 4 and 5 changes](./joomla-4-and-5-changes), code which triggers the Events can use a `GenericEvent` or a concrete Event, eg `ContentPrepareEvent`. In both these cases you can get the arguments using
+As explained in [Joomla 4 and 5 changes](./joomla-4-and-5-changes.md), code which triggers the Events can use a `GenericEvent` or a concrete Event, eg `ContentPrepareEvent`. In both these cases you can get the arguments using
 
 ```php
 [$context, $article, $params, $page] = array_values($event->getArguments());

--- a/versioned_docs/version-5.0/general-concepts/javascript/js-library/joomla-dialog.md
+++ b/versioned_docs/version-5.0/general-concepts/javascript/js-library/joomla-dialog.md
@@ -3,7 +3,7 @@ Joomla Dialog (popup) script
 
 Joomla Dialog module provides a functionality which allows to display various Dialogs (popup) windows. 
 
-To add Joomla Dialog module to the page use [WebAssetManager](../../web-asset-manager) `$wa->useScript('joomla.dialog')`, 
+To add Joomla Dialog module to the page use [WebAssetManager](../../web-asset-manager.md) `$wa->useScript('joomla.dialog')`, 
 and to enable auto binding of the buttons on the page use `$wa->useScript('joomla.dialog-autocreate')`.
 
 Joomla Dialog allows to display dialogs with following content:

--- a/versioned_docs/version-5.0/security/common-vulnerabilities.md
+++ b/versioned_docs/version-5.0/security/common-vulnerabilities.md
@@ -25,7 +25,7 @@ With the output template given above, the JS provided by the user will be output
 ### Prevention
 #### Filter/validate the user input
 In the example above, the provided subject should be filtered and/or validated to only allow required characters - and it should disallow characters that are needed to create HTML tags, i.e. the `<` and `>` characters.
-If the user input can contain HTML markup, the markup itself has to be filtered to make sure it only contains safe markup. See [the chapter about input handling](input-handling) for more information.
+If the user input can contain HTML markup, the markup itself has to be filtered to make sure it only contains safe markup. See [the chapter about input handling](input-handling.md) for more information.
 
 #### Escape the output
 Unless user generated markup is specifically needed (i.e. because the user can use a WYSIWYG editor) it's highly recommended to escape each and every snippet of user provided content.
@@ -36,7 +36,7 @@ To escape user content in Joomla, use the ```echo $this->escape($evilString)``` 
 ## SQL injections / SQLi
 A SQL injection attack is a type of vulnerability where an attacker is able to manipulate a SQL query by injecting user controlled content.
 
-Learn more about this attack scenario and the prevention in [the chapter about secure DB queries](secure-db-queries).
+Learn more about this attack scenario and the prevention in [the chapter about secure DB queries](secure-db-queries.md).
 
 ## Unrestricted file uploads
 Uploading user provided files to a webservers is a potentially dangerous task as it exposes multiple attack vectors at once:
@@ -50,4 +50,4 @@ Therefore file uploads must be very carefully implemented. Check the ```canUploa
 CSRF is an attack type where an HTML form on an external, attacker-controlled site is used to perform an attack against a target site. 
 
 ### Prevention
-Learn more about this in the [CSRF chapter](csrf-protection) of this manual.
+Learn more about this in the [CSRF chapter](csrf-protection.md) of this manual.

--- a/versioned_docs/version-5.0/security/forms.md
+++ b/versioned_docs/version-5.0/security/forms.md
@@ -4,4 +4,4 @@ sidebar_position: 6
 
 Forms & Validations
 ======================
-See the [form validation chapter for further information](../general-concepts/forms/server-side-validation).
+See the [form validation chapter for further information](../general-concepts/forms/server-side-validation.md).

--- a/versioned_docs/version-5.0/security/input-handling.md
+++ b/versioned_docs/version-5.0/security/input-handling.md
@@ -5,4 +5,4 @@ sidebar_position: 3
 Input Handling
 ======================
 
-See the [Input chapter for further information](../general-concepts/input).
+See the [Input chapter for further information](../general-concepts/input.md).

--- a/versioned_docs/version-5.1/building-extensions/components/component-examples/ajaxdemo.md
+++ b/versioned_docs/version-5.1/building-extensions/components/component-examples/ajaxdemo.md
@@ -63,7 +63,7 @@ Path: components/com_ajaxdemo/tmpl/ajaxdemo/default.php
 
 This uses the [Web Asset Manager](../../../general-concepts/web-asset-manager.md) to attach the JavaScript divide.js which initiates the Ajax call.
 
-It passes the root URL of your Joomla instance to the JavaScript code using [passing variables to Javascript](../../../general-concepts/javascript/adding-javascript#passing-variables-to-javascript)
+It passes the root URL of your Joomla instance to the JavaScript code using [passing variables to Javascript](../../../general-concepts/javascript/adding-javascript.md#passing-variables-to-javascript)
 as this makes the job of forming the URLs easier.
 
 Then it outputs the `<form>` html, including the button with the onclick listener to run the divide.js code.

--- a/versioned_docs/version-5.1/building-extensions/plugins/basic-content-plugin.md
+++ b/versioned_docs/version-5.1/building-extensions/plugins/basic-content-plugin.md
@@ -173,7 +173,7 @@ Ensure that this matches your class in your `src/Extension` directory.
 ## Extension Class
 This is the main code of the plugin. Hopefully the comments in the code explain what is going on.
 
-As explained in [Joomla 4 and 5 changes](./joomla-4-and-5-changes), code which triggers the Events can use a `GenericEvent` or a concrete Event, eg `ContentPrepareEvent`. In both these cases you can get the arguments using
+As explained in [Joomla 4 and 5 changes](./joomla-4-and-5-changes.md), code which triggers the Events can use a `GenericEvent` or a concrete Event, eg `ContentPrepareEvent`. In both these cases you can get the arguments using
 
 ```php
 [$context, $article, $params, $page] = array_values($event->getArguments());

--- a/versioned_docs/version-5.1/general-concepts/javascript/ajax.md
+++ b/versioned_docs/version-5.1/general-concepts/javascript/ajax.md
@@ -31,7 +31,7 @@ Within your component you should use the [MVC approach](../../building-extension
 and split your functionality into different Controllers, Models and Views.
 
 The default Joomla [Extension/Dispatcher](../extension-and-dispatcher/index.md) code uses the URL 
-[`task` parameter](../../building-extensions/components/mvc/mvc-overview#the-http-request-task-parameter) 
+[`task` parameter](../../building-extensions/components/mvc/mvc-overview.md#the-http-request-task-parameter) 
 to determine the Controller class to instantiate and the method within that Controller to call.
 
 For example, if you set the `task` parameter to "ajax.divide" then the default Dispatcher code will instantiate your AjaxController and call its `divide` instance method.

--- a/versioned_docs/version-5.1/general-concepts/javascript/js-library/joomla-dialog.md
+++ b/versioned_docs/version-5.1/general-concepts/javascript/js-library/joomla-dialog.md
@@ -3,7 +3,7 @@ Joomla Dialog (popup) script
 
 Joomla Dialog module provides a functionality which allows to display various Dialogs (popup) windows. 
 
-To add Joomla Dialog module to the page use [WebAssetManager](../../web-asset-manager) `$wa->useScript('joomla.dialog')`, 
+To add Joomla Dialog module to the page use [WebAssetManager](../../web-asset-manager.md) `$wa->useScript('joomla.dialog')`, 
 and to enable auto binding of the buttons on the page use `$wa->useScript('joomla.dialog-autocreate')`.
 
 Joomla Dialog allows to display dialogs with following content:

--- a/versioned_docs/version-5.1/security/common-vulnerabilities.md
+++ b/versioned_docs/version-5.1/security/common-vulnerabilities.md
@@ -25,7 +25,7 @@ With the output template given above, the JS provided by the user will be output
 ### Prevention
 #### Filter/validate the user input
 In the example above, the provided subject should be filtered and/or validated to only allow required characters - and it should disallow characters that are needed to create HTML tags, i.e. the `<` and `>` characters.
-If the user input can contain HTML markup, the markup itself has to be filtered to make sure it only contains safe markup. See [the chapter about input handling](input-handling) for more information.
+If the user input can contain HTML markup, the markup itself has to be filtered to make sure it only contains safe markup. See [the chapter about input handling](input-handling.md) for more information.
 
 #### Escape the output
 Unless user generated markup is specifically needed (i.e. because the user can use a WYSIWYG editor) it's highly recommended to escape each and every snippet of user provided content.
@@ -36,7 +36,7 @@ To escape user content in Joomla, use the ```echo $this->escape($evilString)``` 
 ## SQL injections / SQLi
 A SQL injection attack is a type of vulnerability where an attacker is able to manipulate a SQL query by injecting user controlled content.
 
-Learn more about this attack scenario and the prevention in [the chapter about secure DB queries](secure-db-queries).
+Learn more about this attack scenario and the prevention in [the chapter about secure DB queries](secure-db-queries.md).
 
 ## Unrestricted file uploads
 Uploading user provided files to a webservers is a potentially dangerous task as it exposes multiple attack vectors at once:
@@ -50,4 +50,4 @@ Therefore file uploads must be very carefully implemented. Check the ```canUploa
 CSRF is an attack type where an HTML form on an external, attacker-controlled site is used to perform an attack against a target site. 
 
 ### Prevention
-Learn more about this in the [CSRF chapter](csrf-protection) of this manual.
+Learn more about this in the [CSRF chapter](csrf-protection.md) of this manual.

--- a/versioned_docs/version-5.1/security/forms.md
+++ b/versioned_docs/version-5.1/security/forms.md
@@ -4,4 +4,4 @@ sidebar_position: 6
 
 Forms & Validations
 ======================
-See the [form validation chapter for further information](../general-concepts/forms/server-side-validation).
+See the [form validation chapter for further information](../general-concepts/forms/server-side-validation.md).

--- a/versioned_docs/version-5.1/security/input-handling.md
+++ b/versioned_docs/version-5.1/security/input-handling.md
@@ -5,4 +5,4 @@ sidebar_position: 3
 Input Handling
 ======================
 
-See the [Input chapter for further information](../general-concepts/input).
+See the [Input chapter for further information](../general-concepts/input.md).

--- a/versioned_docs/version-5.2/building-extensions/components/component-examples/ajaxdemo.md
+++ b/versioned_docs/version-5.2/building-extensions/components/component-examples/ajaxdemo.md
@@ -63,7 +63,7 @@ Path: components/com_ajaxdemo/tmpl/ajaxdemo/default.php
 
 This uses the [Web Asset Manager](../../../general-concepts/web-asset-manager.md) to attach the JavaScript divide.js which initiates the Ajax call.
 
-It passes the root URL of your Joomla instance to the JavaScript code using [passing variables to Javascript](../../../general-concepts/javascript/adding-javascript#passing-variables-to-javascript)
+It passes the root URL of your Joomla instance to the JavaScript code using [passing variables to Javascript](../../../general-concepts/javascript/adding-javascript.md#passing-variables-to-javascript)
 as this makes the job of forming the URLs easier.
 
 Then it outputs the `<form>` html, including the button with the onclick listener to run the divide.js code.

--- a/versioned_docs/version-5.2/building-extensions/plugins/basic-content-plugin.md
+++ b/versioned_docs/version-5.2/building-extensions/plugins/basic-content-plugin.md
@@ -173,7 +173,7 @@ Ensure that this matches your class in your `src/Extension` directory.
 ## Extension Class
 This is the main code of the plugin. Hopefully the comments in the code explain what is going on.
 
-As explained in [Joomla 4 and 5 changes](./joomla-4-and-5-changes), code which triggers the Events can use a `GenericEvent` or a concrete Event, eg `ContentPrepareEvent`. In both these cases you can get the arguments using
+As explained in [Joomla 4 and 5 changes](./joomla-4-and-5-changes.md), code which triggers the Events can use a `GenericEvent` or a concrete Event, eg `ContentPrepareEvent`. In both these cases you can get the arguments using
 
 ```php
 [$context, $article, $params, $page] = array_values($event->getArguments());

--- a/versioned_docs/version-5.2/general-concepts/javascript/ajax.md
+++ b/versioned_docs/version-5.2/general-concepts/javascript/ajax.md
@@ -31,7 +31,7 @@ Within your component you should use the [MVC approach](../../building-extension
 and split your functionality into different Controllers, Models and Views.
 
 The default Joomla [Extension/Dispatcher](../extension-and-dispatcher/index.md) code uses the URL 
-[`task` parameter](../../building-extensions/components/mvc/mvc-overview#the-http-request-task-parameter) 
+[`task` parameter](../../building-extensions/components/mvc/mvc-overview.md#the-http-request-task-parameter) 
 to determine the Controller class to instantiate and the method within that Controller to call.
 
 For example, if you set the `task` parameter to "ajax.divide" then the default Dispatcher code will instantiate your AjaxController and call its `divide` instance method.

--- a/versioned_docs/version-5.2/general-concepts/javascript/js-library/joomla-dialog.md
+++ b/versioned_docs/version-5.2/general-concepts/javascript/js-library/joomla-dialog.md
@@ -3,7 +3,7 @@ Joomla Dialog (popup) script
 
 Joomla Dialog module provides a functionality which allows to display various Dialogs (popup) windows. 
 
-To add Joomla Dialog module to the page use [WebAssetManager](../../web-asset-manager) `$wa->useScript('joomla.dialog')`, 
+To add Joomla Dialog module to the page use [WebAssetManager](../../web-asset-manager.md) `$wa->useScript('joomla.dialog')`, 
 and to enable auto binding of the buttons on the page use `$wa->useScript('joomla.dialog-autocreate')`.
 
 Joomla Dialog allows to display dialogs with following content:

--- a/versioned_docs/version-5.2/security/common-vulnerabilities.md
+++ b/versioned_docs/version-5.2/security/common-vulnerabilities.md
@@ -25,7 +25,7 @@ With the output template given above, the JS provided by the user will be output
 ### Prevention
 #### Filter/validate the user input
 In the example above, the provided subject should be filtered and/or validated to only allow required characters - and it should disallow characters that are needed to create HTML tags, i.e. the `<` and `>` characters.
-If the user input can contain HTML markup, the markup itself has to be filtered to make sure it only contains safe markup. See [the chapter about input handling](input-handling) for more information.
+If the user input can contain HTML markup, the markup itself has to be filtered to make sure it only contains safe markup. See [the chapter about input handling](input-handling.md) for more information.
 
 #### Escape the output
 Unless user generated markup is specifically needed (i.e. because the user can use a WYSIWYG editor) it's highly recommended to escape each and every snippet of user provided content.
@@ -36,7 +36,7 @@ To escape user content in Joomla, use the ```echo $this->escape($evilString)``` 
 ## SQL injections / SQLi
 A SQL injection attack is a type of vulnerability where an attacker is able to manipulate a SQL query by injecting user controlled content.
 
-Learn more about this attack scenario and the prevention in [the chapter about secure DB queries](secure-db-queries).
+Learn more about this attack scenario and the prevention in [the chapter about secure DB queries](secure-db-queries.md).
 
 ## Unrestricted file uploads
 Uploading user provided files to a webservers is a potentially dangerous task as it exposes multiple attack vectors at once:
@@ -50,4 +50,4 @@ Therefore file uploads must be very carefully implemented. Check the ```canUploa
 CSRF is an attack type where an HTML form on an external, attacker-controlled site is used to perform an attack against a target site. 
 
 ### Prevention
-Learn more about this in the [CSRF chapter](csrf-protection) of this manual.
+Learn more about this in the [CSRF chapter](csrf-protection.md) of this manual.

--- a/versioned_docs/version-5.2/security/forms.md
+++ b/versioned_docs/version-5.2/security/forms.md
@@ -4,4 +4,4 @@ sidebar_position: 6
 
 Forms & Validations
 ======================
-See the [form validation chapter for further information](../general-concepts/forms/server-side-validation).
+See the [form validation chapter for further information](../general-concepts/forms/server-side-validation.md).

--- a/versioned_docs/version-5.2/security/input-handling.md
+++ b/versioned_docs/version-5.2/security/input-handling.md
@@ -5,4 +5,4 @@ sidebar_position: 3
 Input Handling
 ======================
 
-See the [Input chapter for further information](../general-concepts/input).
+See the [Input chapter for further information](../general-concepts/input.md).


### PR DESCRIPTION
Google is not happy with the current "undefined" situation of canonical urls in combination with the webhosting.

Our canonical path is not the same as the path linked and opened or redirected.

This test tries to solve this by forcing a trailing slash (disabling trailing slash didn't work).

As side effect I fixed some wrong links.