### PR TITLE
fixed link getting the Document via ->app instead of

### DIFF
--- a/docs/building-extensions/modules/module-development-tutorial/step7-javascript.md
+++ b/docs/building-extensions/modules/module-development-tutorial/step7-javascript.md
@@ -102,7 +102,7 @@ Our updated tmpl file is:
 defined('_JEXEC') or die;
 
 // highlight-start
-$document = $app->getDocument();
+$document = $this->app->getDocument();
 $wa = $document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('mod_hello');
 $wa->useScript('mod_hello.add-suffix');

--- a/versioned_docs/version-4.4/building-extensions/modules/module-development-tutorial/step7-javascript.md
+++ b/versioned_docs/version-4.4/building-extensions/modules/module-development-tutorial/step7-javascript.md
@@ -102,7 +102,7 @@ Our updated tmpl file is:
 defined('_JEXEC') or die;
 
 // highlight-start
-$document = $app->getDocument();
+$document = $this->app->getDocument();
 $wa = $document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('mod_hello');
 $wa->useScript('mod_hello.add-suffix');

--- a/versioned_docs/version-5.0/building-extensions/modules/module-development-tutorial/step7-javascript.md
+++ b/versioned_docs/version-5.0/building-extensions/modules/module-development-tutorial/step7-javascript.md
@@ -102,7 +102,7 @@ Our updated tmpl file is:
 defined('_JEXEC') or die;
 
 // highlight-start
-$document = $app->getDocument();
+$document = $this->app->getDocument();
 $wa = $document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('mod_hello');
 $wa->useScript('mod_hello.add-suffix');

--- a/versioned_docs/version-5.1/building-extensions/modules/module-development-tutorial/step7-javascript.md
+++ b/versioned_docs/version-5.1/building-extensions/modules/module-development-tutorial/step7-javascript.md
@@ -85,7 +85,7 @@ The Web Asset Manager doesn't automatically read the joomla.asset.json files of 
 Then we need to tell it that we want to use the "mod_hello.add-suffix" asset, so that our js file gets included in the HTTP response:
 
 ```php
-$document = $app->getDocument();
+$document = $this->app->getDocument();
 $wa = $document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('mod_hello');
 $wa->useScript('mod_hello.add-suffix');

--- a/versioned_docs/version-5.2/building-extensions/modules/module-development-tutorial/step7-javascript.md
+++ b/versioned_docs/version-5.2/building-extensions/modules/module-development-tutorial/step7-javascript.md
@@ -85,7 +85,7 @@ The Web Asset Manager doesn't automatically read the joomla.asset.json files of 
 Then we need to tell it that we want to use the "mod_hello.add-suffix" asset, so that our js file gets included in the HTTP response:
 
 ```php
-$document = $app->getDocument();
+$document = $this->app->getDocument();
 $wa = $document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('mod_hello');
 $wa->useScript('mod_hello.add-suffix');


### PR DESCRIPTION
Fixes #336 - a problem in module tutorial step 7

It looks like the other tutorial steps are correct, and the code in the manual-examples repo is correct as well.