### PR TITLE
Add docu for new update event

### DIFF
--- a/docs/building-extensions/plugins/plugin-events/index.md
+++ b/docs/building-extensions/plugins/plugin-events/index.md
@@ -29,3 +29,5 @@ The event Group refers to the group of plugins which Joomla ensures are imported
 | [onContentBeforeChangeState](./content.md#oncontentbeforechangestate) | In Model, before a set of records changes state | Content      |  4.0  |
 | [onContentChangeState](./content.md#oncontentchangestate) | In Model, after a set of records changes state | Content          |  before 4.0  |
 | [onCategoryChangeState](./content.md#oncategorychangestate) | In Model, before a set of category records changes state | Content     |  before 4.0  |
+| [onInstallerBeforePackageDownload](./installer.md#onInstallerBeforePackageDownload) | In Installer, before a package is downloaded | Installer     |  before 4.0  |
+| [onInstallerBeforeUpdateSiteDownload](./installer.md#onInstallerBeforeUpdateSiteDownload) | In Installer, before an update site is downloaded | Installer     |  5.3  |

--- a/docs/building-extensions/plugins/plugin-events/index.md
+++ b/docs/building-extensions/plugins/plugin-events/index.md
@@ -30,6 +30,5 @@ The event Group refers to the group of plugins which Joomla ensures are imported
 | [onContentChangeState](./content.md#oncontentchangestate) | In Model, after a set of records changes state | Content          |  before 4.0  |
 | [onCategoryChangeState](./content.md#oncategorychangestate) | In Model, before a set of category records changes state | Content     |  before 4.0  |
 | [onInstallerBeforePackageDownload](./installer.md#oninstallerbeforepackagedownload) | In Installer, before a package is downloaded | Installer     |  before 4.0  |
-
 | [onInstallerBeforeUpdateSiteDownload](./installer.md#oninstallerbeforeupdatesitedownload) | In Installer, before an update site is downloaded | Installer     |  5.3  |
 

--- a/docs/building-extensions/plugins/plugin-events/index.md
+++ b/docs/building-extensions/plugins/plugin-events/index.md
@@ -29,6 +29,7 @@ The event Group refers to the group of plugins which Joomla ensures are imported
 | [onContentBeforeChangeState](./content.md#oncontentbeforechangestate) | In Model, before a set of records changes state | Content      |  4.0  |
 | [onContentChangeState](./content.md#oncontentchangestate) | In Model, after a set of records changes state | Content          |  before 4.0  |
 | [onCategoryChangeState](./content.md#oncategorychangestate) | In Model, before a set of category records changes state | Content     |  before 4.0  |
-| [onInstallerBeforePackageDownload](./installer.md#onInstallerBeforePackageDownload) | In Installer, before a package is downloaded | Installer     |  before 4.0  |
+| [onInstallerBeforePackageDownload](./installer.md#oninstallerbeforepackagedownload) | In Installer, before a package is downloaded | Installer     |  before 4.0  |
+
 | [onInstallerBeforeUpdateSiteDownload](./installer.md#oninstallerbeforeupdatesitedownload) | In Installer, before an update site is downloaded | Installer     |  5.3  |
 

--- a/docs/building-extensions/plugins/plugin-events/index.md
+++ b/docs/building-extensions/plugins/plugin-events/index.md
@@ -30,4 +30,5 @@ The event Group refers to the group of plugins which Joomla ensures are imported
 | [onContentChangeState](./content.md#oncontentchangestate) | In Model, after a set of records changes state | Content          |  before 4.0  |
 | [onCategoryChangeState](./content.md#oncategorychangestate) | In Model, before a set of category records changes state | Content     |  before 4.0  |
 | [onInstallerBeforePackageDownload](./installer.md#onInstallerBeforePackageDownload) | In Installer, before a package is downloaded | Installer     |  before 4.0  |
-| [onInstallerBeforeUpdateSiteDownload](./installer.md#onInstallerBeforeUpdateSiteDownload) | In Installer, before an update site is downloaded | Installer     |  5.3  |
+| [onInstallerBeforeUpdateSiteDownload](./installer.md#oninstallerbeforeupdatesitedownload) | In Installer, before an update site is downloaded | Installer     |  5.3  |
+

--- a/docs/building-extensions/plugins/plugin-events/installer.md
+++ b/docs/building-extensions/plugins/plugin-events/installer.md
@@ -1,0 +1,63 @@
+---
+sidebar_position: 1
+title: Installer Events
+toc_max_heading_level: 2 
+---
+
+Installer Events
+==============
+
+Installer plugin events are triggered when some routines are performed during the install process of extensions or when their update sites are downloaded.
+
+## onInstallerBeforePackageDownload
+
+### Description
+
+This event will be executed before a package of an extension is downloaded. It allows to modify the url or headers for the request. 
+
+### Event Arguments
+
+The event class \Joomla\CMS\Event\Installer\BeforePackageDownloadEvent has the following arguments:
+
+- **`url`** - The url of the package.
+
+- **`headers`** - The headers which are sent with the request.
+
+### Return Value
+
+None.
+
+### Examples
+
+```php
+public function onInstallerBeforePackageDownload(\Joomla\CMS\Event\Installer\BeforePackageDownloadEvent $event): void
+{
+    $event->updateUrl($event->getUrl() . '?auth=foo');
+}
+
+## onInstallerBeforeUpdateSiteDownload
+
+### Description
+
+This event will be executed before an update site is downloaded. It allows to modify the url or headers for the request. 
+
+### Event Arguments
+
+The event class \Joomla\CMS\Event\Installer\BeforeUpdateSiteDownloadEvent has the following arguments:
+
+- **`url`** - The url of the update site.
+
+- **`headers`** - The headers which are sent with the request.
+
+### Return Value
+
+None.
+
+### Examples
+
+```php
+public function onInstallerBeforeUpdateSiteDownload(\Joomla\CMS\Event\Installer\BeforeUpdateSiteDownloadEvent $event): void
+{
+    $event->updateUrl($event->getUrl() . '?auth=foo');
+}
+```

--- a/docs/building-extensions/plugins/plugin-events/installer.md
+++ b/docs/building-extensions/plugins/plugin-events/installer.md
@@ -47,7 +47,8 @@ This event will be executed before an update site is downloaded. It allows to mo
 
 ### Event Arguments
 
-The event class \Joomla\CMS\Event\Installer\BeforeUpdateSiteDownloadEvent has the following arguments:
+The event class `\Joomla\CMS\Event\Installer\BeforeUpdateSiteDownloadEvent` has the following arguments:
+
 
 - **`url`** - The url of the update site.
 

--- a/docs/building-extensions/plugins/plugin-events/installer.md
+++ b/docs/building-extensions/plugins/plugin-events/installer.md
@@ -19,7 +19,8 @@ This event will be executed before an installable package (zip file) of an exten
 
 ### Event Arguments
 
-The event class \Joomla\CMS\Event\Installer\BeforePackageDownloadEvent has the following arguments:
+The event class `\Joomla\CMS\Event\Installer\BeforePackageDownloadEvent` has the following arguments:
+
 
 - **`url`** - The url of the package.
 

--- a/docs/building-extensions/plugins/plugin-events/installer.md
+++ b/docs/building-extensions/plugins/plugin-events/installer.md
@@ -5,7 +5,8 @@ toc_max_heading_level: 2
 ---
 
 Installer Events
-==============
+================
+
 
 Installer plugin events are triggered when some routines are performed during the install process of extensions or when their update sites are downloaded.
 

--- a/docs/building-extensions/plugins/plugin-events/installer.md
+++ b/docs/building-extensions/plugins/plugin-events/installer.md
@@ -13,7 +13,7 @@ Installer plugin events are triggered when some routines are performed during th
 
 ### Description
 
-This event will be executed before a package of an extension is downloaded. It allows plugins to modify the url or headers for the request. 
+This event will be executed before an installable package (zip file) of an extension (package, component, module, plugin, template, library) is downloaded. It allows plugins to modify the url or headers for the request. 
 
 
 ### Event Arguments
@@ -35,6 +35,7 @@ public function onInstallerBeforePackageDownload(\Joomla\CMS\Event\Installer\Bef
 {
     $event->updateUrl($event->getUrl() . '?auth=foo');
 }
+```
 
 ## onInstallerBeforeUpdateSiteDownload
 

--- a/docs/building-extensions/plugins/plugin-events/installer.md
+++ b/docs/building-extensions/plugins/plugin-events/installer.md
@@ -13,7 +13,8 @@ Installer plugin events are triggered when some routines are performed during th
 
 ### Description
 
-This event will be executed before a package of an extension is downloaded. It allows to modify the url or headers for the request. 
+This event will be executed before a package of an extension is downloaded. It allows plugins to modify the url or headers for the request. 
+
 
 ### Event Arguments
 

--- a/migrations/52-53/new-features.md
+++ b/migrations/52-53/new-features.md
@@ -51,3 +51,16 @@ $this->form
 // Code in the form layout
 echo $this->form->renderControlFields();
 ```
+
+#### New before download update site event
+A new event is available where an installer plugin can hook in before an update site url is fetched. Similar to what we have for package download of an extension.
+
+PR: https://github.com/joomla/joomla-cms/pull/44516
+
+The event can be used like:
+```php
+public function onInstallerBeforeUpdateSiteDownload(\Joomla\CMS\Event\Installer\BeforeUpdateSiteDownloadEvent $event): void
+{
+    $event->updateUrl($event->getUrl() . '?auth=foo');
+}
+```

--- a/migrations/52-53/new-features.md
+++ b/migrations/52-53/new-features.md
@@ -53,6 +53,7 @@ echo $this->form->renderControlFields();
 ```
 
 #### New before download update site event
+
 A new event is available where an installer plugin can hook in before an update site url is fetched. Similar to what we have for package download of an extension.
 
 PR: https://github.com/joomla/joomla-cms/pull/44516

--- a/versioned_docs/version-4.4/building-extensions/plugins/plugin-events/index.md
+++ b/versioned_docs/version-4.4/building-extensions/plugins/plugin-events/index.md
@@ -29,3 +29,4 @@ The event Group refers to the group of plugins which Joomla ensures are imported
 | [onContentBeforeChangeState](./content.md#oncontentbeforechangestate) | In Model, before a set of records changes state | Content      |  4.0  |
 | [onContentChangeState](./content.md#oncontentchangestate) | In Model, after a set of records changes state | Content          |  before 4.0  |
 | [onCategoryChangeState](./content.md#oncategorychangestate) | In Model, before a set of category records changes state | Content     |  before 4.0  |
+| [onInstallerBeforePackageDownload](./installer.md#oninstallerbeforepackagedownload) | In Installer, before a package is downloaded | Installer     |  before 4.0  |

--- a/versioned_docs/version-4.4/building-extensions/plugins/plugin-events/installer.md
+++ b/versioned_docs/version-4.4/building-extensions/plugins/plugin-events/installer.md
@@ -1,0 +1,39 @@
+---
+sidebar_position: 1
+title: Installer Events
+toc_max_heading_level: 2 
+---
+
+Installer Events
+==============
+
+Installer plugin events are triggered when some routines are performed during the install process of extensions or when their update sites are downloaded.
+
+## onInstallerBeforePackageDownload
+
+### Description
+
+This event will be executed before an installable package (zip file) of an extension (package, component, module, plugin, template, library) is downloaded. It allows plugins to modify the url or headers for the request. 
+
+
+### Event Arguments
+
+The event class \Joomla\CMS\Event\Installer\BeforePackageDownloadEvent has the following arguments:
+
+- **`url`** - The url of the package.
+
+- **`headers`** - The headers which are sent with the request.
+
+### Return Value
+
+None.
+
+### Examples
+
+```php
+public function onInstallerBeforePackageDownload(\Joomla\CMS\Event\Installer\BeforePackageDownloadEvent $event): void
+{
+    $event->updateUrl($event->getUrl() . '?auth=foo');
+}
+```
+

--- a/versioned_docs/version-4.4/building-extensions/plugins/plugin-events/installer.md
+++ b/versioned_docs/version-4.4/building-extensions/plugins/plugin-events/installer.md
@@ -19,7 +19,8 @@ This event will be executed before an installable package (zip file) of an exten
 
 ### Event Arguments
 
-The event class \Joomla\CMS\Event\Installer\BeforePackageDownloadEvent has the following arguments:
+The event class  `\Joomla\CMS\Event\Installer\BeforePackageDownloadEvent` has the following arguments:
+
 
 - **`url`** - The url of the package.
 

--- a/versioned_docs/version-4.4/building-extensions/plugins/plugin-events/installer.md
+++ b/versioned_docs/version-4.4/building-extensions/plugins/plugin-events/installer.md
@@ -5,7 +5,8 @@ toc_max_heading_level: 2
 ---
 
 Installer Events
-==============
+================
+
 
 Installer plugin events are triggered when some routines are performed during the install process of extensions or when their update sites are downloaded.
 

--- a/versioned_docs/version-5.2/building-extensions/plugins/plugin-events/index.md
+++ b/versioned_docs/version-5.2/building-extensions/plugins/plugin-events/index.md
@@ -29,3 +29,4 @@ The event Group refers to the group of plugins which Joomla ensures are imported
 | [onContentBeforeChangeState](./content.md#oncontentbeforechangestate) | In Model, before a set of records changes state | Content      |  4.0  |
 | [onContentChangeState](./content.md#oncontentchangestate) | In Model, after a set of records changes state | Content          |  before 4.0  |
 | [onCategoryChangeState](./content.md#oncategorychangestate) | In Model, before a set of category records changes state | Content     |  before 4.0  |
+| [onInstallerBeforePackageDownload](./installer.md#oninstallerbeforepackagedownload) | In Installer, before a package is downloaded | Installer     |  before 4.0  |

--- a/versioned_docs/version-5.2/building-extensions/plugins/plugin-events/installer.md
+++ b/versioned_docs/version-5.2/building-extensions/plugins/plugin-events/installer.md
@@ -1,0 +1,39 @@
+---
+sidebar_position: 1
+title: Installer Events
+toc_max_heading_level: 2 
+---
+
+Installer Events
+==============
+
+Installer plugin events are triggered when some routines are performed during the install process of extensions or when their update sites are downloaded.
+
+## onInstallerBeforePackageDownload
+
+### Description
+
+This event will be executed before an installable package (zip file) of an extension (package, component, module, plugin, template, library) is downloaded. It allows plugins to modify the url or headers for the request. 
+
+
+### Event Arguments
+
+The event class \Joomla\CMS\Event\Installer\BeforePackageDownloadEvent has the following arguments:
+
+- **`url`** - The url of the package.
+
+- **`headers`** - The headers which are sent with the request.
+
+### Return Value
+
+None.
+
+### Examples
+
+```php
+public function onInstallerBeforePackageDownload(\Joomla\CMS\Event\Installer\BeforePackageDownloadEvent $event): void
+{
+    $event->updateUrl($event->getUrl() . '?auth=foo');
+}
+```
+

--- a/versioned_docs/version-5.2/building-extensions/plugins/plugin-events/installer.md
+++ b/versioned_docs/version-5.2/building-extensions/plugins/plugin-events/installer.md
@@ -19,7 +19,8 @@ This event will be executed before an installable package (zip file) of an exten
 
 ### Event Arguments
 
-The event class \Joomla\CMS\Event\Installer\BeforePackageDownloadEvent has the following arguments:
+The event class `\Joomla\CMS\Event\Installer\BeforePackageDownloadEvent` has the following arguments:
+
 
 - **`url`** - The url of the package.
 

--- a/versioned_docs/version-5.2/building-extensions/plugins/plugin-events/installer.md
+++ b/versioned_docs/version-5.2/building-extensions/plugins/plugin-events/installer.md
@@ -5,7 +5,8 @@ toc_max_heading_level: 2
 ---
 
 Installer Events
-==============
+================
+
 
 Installer plugin events are triggered when some routines are performed during the install process of extensions or when their update sites are downloaded.
 


### PR DESCRIPTION
### **User description**
Docs for https://github.com/joomla/joomla-cms/pull/44516


___

### **PR Type**
documentation


___

### **Description**
- Added documentation for new installer plugin events: `onInstallerBeforePackageDownload` and `onInstallerBeforeUpdateSiteDownload`.
- Provided detailed descriptions and examples for using these events in the Joomla CMS.
- Updated migration notes to include information about the new event for fetching update site URLs.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>installer.md</strong><dd><code>Document new installer plugin events and examples</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/building-extensions/plugins/plugin-events/installer.md

<li>Added documentation for installer events.<br> <li> Described <code>onInstallerBeforePackageDownload</code> event.<br> <li> Described <code>onInstallerBeforeUpdateSiteDownload</code> event.<br> <li> Provided examples for both events.<br>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/340/files#diff-5a95310ffe99bcb7b34f2202208fef74162a7c76cd59e0176e9fb258b66cb5f9">+63/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>new-features.md</strong><dd><code>Add documentation for new before download update site event</code></dd></summary>
<hr>

migrations/52-53/new-features.md

<li>Documented new event for update site URL fetching.<br> <li> Provided example usage of the new event.<br>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/340/files#diff-769fb3a3756fb2a9b1ccbf4cc11c44035bca43ec5621d7e1061971aacdfbbce3">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information