### PR TITLE
Remove the createThumbs function in the image class

### DIFF
--- a/migrations/54-60/removed-backward-incompatibility.md
+++ b/migrations/54-60/removed-backward-incompatibility.md
@@ -64,3 +64,18 @@ echo $article->get('title');
 $article = $app->bootComponent('content')->getMVCFactory()->createModel('Article', 'Administrator')->getItem(1);
 echo $article->title;
 ```
+
+### createThumbs function got removed from the image class
+
+- PR: https://github.com/joomla/joomla-cms/pull/44663
+- File: libraries/src/Image/Image.php
+- Description: The `createThumbs` function in the `Image` class got removed as the function `createThumbnails` should be used instead. For example you can use 
+```php
+// Old:
+$image = new Image($path);
+$image->createThumbs('50x50');
+
+// New:
+$image = new Image($path);
+$image->createThumbnails('50x50');
+```


### PR DESCRIPTION
### **User description**
https://github.com/joomla/joomla-cms/pull/44663


___

### **PR Type**
Documentation


___

### **Description**
- Added migration documentation for the removal of `createThumbs` function from the Image class
- Provided clear code examples demonstrating how to migrate from `createThumbs` to `createThumbnails`
- Updated backward compatibility documentation to help users update their code



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>removed-backward-incompatibility.md</strong><dd><code>Document Image class API change for thumbnail creation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/54-60/removed-backward-incompatibility.md

<li>Added documentation about the removal of <code>createThumbs</code> function from <br>Image class<br> <li> Provided code examples showing migration from <code>createThumbs</code> to <br><code>createThumbnails</code><br>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/352/files#diff-1b9f27ae2f64c35bc2cdba1c2988613e48b706934385a2e51f36e0e1bd2d23b2">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information