### PR TITLE
fixes for 2 issues - RunHelloCommand and com_exampleform tmpl file to be all lower case

### DIFF
--- a/docs/building-extensions/components/component-examples/example-form-component.md
+++ b/docs/building-extensions/components/component-examples/example-form-component.md
@@ -125,9 +125,9 @@ Path: components/com_exampleform/src/View/ExampleformReturn/HtmlView.php
 
 This simply has a function to accept the data from the Controller, which it stores locally.
 
-## Site ExampleformReturn tmpl file
+## Site exampleformreturn tmpl file
 
-Path: components/com_exampleform/tmpl/exampleformReturn/default.php
+Path: components/com_exampleform/tmpl/exampleformreturn/default.php
 
 This simply outputs the raw and filtered data which was passed to the view.
 

--- a/docs/building-extensions/plugins/plugin-examples/basic-console-plugin-helloworld.md
+++ b/docs/building-extensions/plugins/plugin-examples/basic-console-plugin-helloworld.md
@@ -241,7 +241,7 @@ class HelloworldConsolePlugin extends CMSPlugin implements SubscriberInterface
 ### Command file
 The file below handles the execution of the hello:world command.
 
-```php title="plg_helloworld_cli/src/CliCommand/RunHelloworldCommand.php"
+```php title="plg_helloworld_cli/src/CliCommand/RunHelloCommand.php"
 <?php
 namespace My\Plugin\Console\Helloworld\CliCommand;
 

--- a/versioned_docs/version-4.4/building-extensions/components/component-examples/example-form-component.md
+++ b/versioned_docs/version-4.4/building-extensions/components/component-examples/example-form-component.md
@@ -125,9 +125,9 @@ Path: components/com_exampleform/src/View/ExampleformReturn/HtmlView.php
 
 This simply has a function to accept the data from the Controller, which it stores locally.
 
-## Site ExampleformReturn tmpl file
+## Site exampleformreturn tmpl file
 
-Path: components/com_exampleform/tmpl/exampleformReturn/default.php
+Path: components/com_exampleform/tmpl/exampleformreturn/default.php
 
 This simply outputs the raw and filtered data which was passed to the view.
 

--- a/versioned_docs/version-4.4/building-extensions/plugins/plugin-examples/basic-console-plugin-helloworld.md
+++ b/versioned_docs/version-4.4/building-extensions/plugins/plugin-examples/basic-console-plugin-helloworld.md
@@ -241,7 +241,7 @@ class HelloworldConsolePlugin extends CMSPlugin implements SubscriberInterface
 ### Command file
 The file below handles the execution of the hello:world command.
 
-```php title="plg_helloworld_cli/src/CliCommand/RunHelloworldCommand.php"
+```php title="plg_helloworld_cli/src/CliCommand/RunHelloCommand.php"
 <?php
 namespace My\Plugin\Console\Helloworld\CliCommand;
 

--- a/versioned_docs/version-5.0/building-extensions/components/component-examples/example-form-component.md
+++ b/versioned_docs/version-5.0/building-extensions/components/component-examples/example-form-component.md
@@ -125,9 +125,9 @@ Path: components/com_exampleform/src/View/ExampleformReturn/HtmlView.php
 
 This simply has a function to accept the data from the Controller, which it stores locally.
 
-## Site ExampleformReturn tmpl file
+## Site exampleformreturn tmpl file
 
-Path: components/com_exampleform/tmpl/exampleformReturn/default.php
+Path: components/com_exampleform/tmpl/exampleformreturn/default.php
 
 This simply outputs the raw and filtered data which was passed to the view.
 

--- a/versioned_docs/version-5.0/building-extensions/plugins/basic-console-plugin-helloworld.md
+++ b/versioned_docs/version-5.0/building-extensions/plugins/basic-console-plugin-helloworld.md
@@ -236,7 +236,7 @@ class HelloworldConsolePlugin extends CMSPlugin implements SubscriberInterface
 ## Command file
 The file below handles the execution of the hello:world command.
 
-```php title="plg_helloworld_cli/src/CliCommand/RunHelloworldCommand.php"
+```php title="plg_helloworld_cli/src/CliCommand/RunHelloCommand.php"
 <?php
 namespace My\Plugin\Console\Helloworld\CliCommand;
 

--- a/versioned_docs/version-5.1/building-extensions/components/component-examples/example-form-component.md
+++ b/versioned_docs/version-5.1/building-extensions/components/component-examples/example-form-component.md
@@ -125,9 +125,9 @@ Path: components/com_exampleform/src/View/ExampleformReturn/HtmlView.php
 
 This simply has a function to accept the data from the Controller, which it stores locally.
 
-## Site ExampleformReturn tmpl file
+## Site exampleformreturn tmpl file
 
-Path: components/com_exampleform/tmpl/exampleformReturn/default.php
+Path: components/com_exampleform/tmpl/exampleformreturn/default.php
 
 This simply outputs the raw and filtered data which was passed to the view.
 

--- a/versioned_docs/version-5.1/building-extensions/plugins/plugin-examples/basic-console-plugin-helloworld.md
+++ b/versioned_docs/version-5.1/building-extensions/plugins/plugin-examples/basic-console-plugin-helloworld.md
@@ -241,7 +241,7 @@ class HelloworldConsolePlugin extends CMSPlugin implements SubscriberInterface
 ### Command file
 The file below handles the execution of the hello:world command.
 
-```php title="plg_helloworld_cli/src/CliCommand/RunHelloworldCommand.php"
+```php title="plg_helloworld_cli/src/CliCommand/RunHelloCommand.php"
 <?php
 namespace My\Plugin\Console\Helloworld\CliCommand;
 

--- a/versioned_docs/version-5.2/building-extensions/components/component-examples/example-form-component.md
+++ b/versioned_docs/version-5.2/building-extensions/components/component-examples/example-form-component.md
@@ -125,9 +125,9 @@ Path: components/com_exampleform/src/View/ExampleformReturn/HtmlView.php
 
 This simply has a function to accept the data from the Controller, which it stores locally.
 
-## Site ExampleformReturn tmpl file
+## Site exampleformreturn tmpl file
 
-Path: components/com_exampleform/tmpl/exampleformReturn/default.php
+Path: components/com_exampleform/tmpl/exampleformreturn/default.php
 
 This simply outputs the raw and filtered data which was passed to the view.
 

--- a/versioned_docs/version-5.2/building-extensions/plugins/plugin-examples/basic-console-plugin-helloworld.md
+++ b/versioned_docs/version-5.2/building-extensions/plugins/plugin-examples/basic-console-plugin-helloworld.md
@@ -241,7 +241,7 @@ class HelloworldConsolePlugin extends CMSPlugin implements SubscriberInterface
 ### Command file
 The file below handles the execution of the hello:world command.
 
-```php title="plg_helloworld_cli/src/CliCommand/RunHelloworldCommand.php"
+```php title="plg_helloworld_cli/src/CliCommand/RunHelloCommand.php"
 <?php
 namespace My\Plugin\Console\Helloworld\CliCommand;
 


### PR DESCRIPTION
These are fixes for #362 and https://github.com/joomla/manual-examples/issues/43 

