### PR TITLE
Add JoomlaDialog 2nd parameter for header text

### DIFF
--- a/docs/general-concepts/javascript/js-library/joomla-dialog.md
+++ b/docs/general-concepts/javascript/js-library/joomla-dialog.md
@@ -75,8 +75,10 @@ dialog.popupButtons = [
 
 ### Static methods
 
-- `JoomlaDialog.alert(text)` Show a text dialog, with one "okay" button. Returns Promise, that resolves when User closes dialog.
-- `JoomlaDialog.confirm(text)` Show a text dialog, with "Yes/No" buttons. Returns Promise, that resolves when User click one of buttons, with result `true` or `false`.
+- `JoomlaDialog.alert(bodytext,headertext)` Show a text dialog, with one "okay" button. Returns Promise, that resolves when User closes dialog.
+- `JoomlaDialog.confirm(bodytext,headertext)` Show a text dialog, with "Yes/No" buttons. Returns Promise, that resolves when User click one of buttons, with result `true` or `false`.
+
+`.confirm()` and `.alert()` methods take an optional second parameter which will be the header text. If missing the header text defaults to **Info** 
 
 ## Events
 
@@ -145,13 +147,13 @@ dialog.show();
 import JoomlaDialog from 'joomla.dialog';
 
 // Alert
-JoomlaDialog.alert('Chase ball of string eat plants, meow')
+JoomlaDialog.alert('Chase ball of string eat plants, meow','Cat Header')
   .then(() => { 
     console.log('All done'); 
   });
 
 // Confirmation
-JoomlaDialog.confirm('Cheese on toast airedale the big cheese?')
+JoomlaDialog.confirm('Cheese on toast airedale the big cheese?','Mouse Header')
   .then((result) => { 
     console.log(result ? 'Okay' : 'Not okay'); 
   });

--- a/versioned_docs/version-5.2/general-concepts/javascript/js-library/joomla-dialog.md
+++ b/versioned_docs/version-5.2/general-concepts/javascript/js-library/joomla-dialog.md
@@ -153,7 +153,7 @@ JoomlaDialog.alert('Chase ball of string eat plants, meow', 'Cat Header')
   });
 
 // Confirmation
-JoomlaDialog.confirm('Cheese on toast airedale the big cheese?', Mouse Header')
+JoomlaDialog.confirm('Cheese on toast airedale the big cheese?', 'Mouse Header')
   .then((result) => { 
     console.log(result ? 'Okay' : 'Not okay'); 
   });

--- a/versioned_docs/version-5.2/general-concepts/javascript/js-library/joomla-dialog.md
+++ b/versioned_docs/version-5.2/general-concepts/javascript/js-library/joomla-dialog.md
@@ -75,8 +75,10 @@ dialog.popupButtons = [
 
 ### Static methods
 
-- `JoomlaDialog.alert(text)` Show a text dialog, with one "okay" button. Returns Promise, that resolves when User closes dialog.
-- `JoomlaDialog.confirm(text)` Show a text dialog, with "Yes/No" buttons. Returns Promise, that resolves when User click one of buttons, with result `true` or `false`.
+- `JoomlaDialog.alert(bodytext, headertext)` Show a text dialog, with one "okay" button. Returns Promise, that resolves when User closes dialog.
+- `JoomlaDialog.confirm(bodytext, headertext)` Show a text dialog, with "Yes/No" buttons. Returns Promise, that resolves when User click one of buttons, with result `true` or `false`.
+
+`.confirm()` and `.alert()` methods take an optional second parameter which will be the header text. If missing the header text defaults to **Info** 
 
 ## Events
 
@@ -145,13 +147,13 @@ dialog.show();
 import JoomlaDialog from 'joomla.dialog';
 
 // Alert
-JoomlaDialog.alert('Chase ball of string eat plants, meow')
+JoomlaDialog.alert('Chase ball of string eat plants, meow', 'Cat Header')
   .then(() => { 
     console.log('All done'); 
   });
 
 // Confirmation
-JoomlaDialog.confirm('Cheese on toast airedale the big cheese?')
+JoomlaDialog.confirm('Cheese on toast airedale the big cheese?', Mouse Header')
   .then((result) => { 
     console.log(result ? 'Okay' : 'Not okay'); 
   });


### PR DESCRIPTION
### **User description**
JoomlaDialog.confirm() and JoomlaDialog.alert() both take 2 parameters - body text (required) and header text (optional - defaults to "Info". This simply documents the second parameter


___

### **PR Type**
Documentation


___

### **Description**
- Documented the optional second parameter for `JoomlaDialog.alert` and `JoomlaDialog.confirm`.

- Updated examples to include the second parameter usage.

- Clarified default behavior for the header text parameter.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>joomla-dialog.md</strong><dd><code>Document second parameter for JoomlaDialog methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

versioned_docs/version-5.2/general-concepts/javascript/js-library/joomla-dialog.md

<li>Added documentation for the optional second parameter in <br><code>JoomlaDialog.alert</code> and <code>JoomlaDialog.confirm</code>.<br> <li> Updated method descriptions to include the header text parameter.<br> <li> Modified examples to demonstrate the usage of the second parameter.<br> <li> Clarified default value for the header text parameter.


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/366/files#diff-136480f9e0bc950b40a07b6fe74695733a536bd1a8fe0ecfaf468b8db5a4d42d">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>