### PR TITLE
Workaround for trailing slashes bug for assets

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,6 +10,7 @@ steps:
     commands:
       - npm install
       - npm run build
+      - mv webserver/.htaccess build
 
   - name: deployment
     image: joomlaprojects/docker-images:packager
@@ -47,6 +48,6 @@ steps:
 
 ---
 kind: signature
-hmac: 3d1303abd175ffda3aec141c6ea71d541f50f3c3e0752a68330fde5560386a58
+hmac: ae910acaafbf7e06bea4e33c509dbabe08e1edaba7f175d91db4a880030c7cc4
 
 ...

--- a/webserver/.htaccess
+++ b/webserver/.htaccess
@@ -1,0 +1,5 @@
+RewriteEngine On
+
+# Workaround for trailing slashes bug https://github.com/facebook/docusaurus/issues/6282
+RewriteCond %{REQUEST_URI} ^/assets/files/(.+)\.(\w+)/$
+RewriteRule ^ /assets/files/%1.%2 [L,R=301]


### PR DESCRIPTION
### **User description**
Issues #368

Since we are using the trailingSlashes option which adds a slash to the end of each internal url it does this also for asset files like .zip files. There is a fix for images but for files it's not fixed yet see [Docusaurus Issue](https://github.com/facebook/docusaurus/issues/6282).

We simply redirect urls with trailing slash located in /assests/files path to the version without trailing slash.


___

### **PR Type**
Bug fix, Configuration changes


___

### **Description**
- Added a workaround for trailing slashes in asset URLs.

- Updated `.drone.yml` to include `.htaccess` in the build process.

- Introduced `.htaccess` file to handle trailing slash redirection for assets.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.drone.yml</strong><dd><code>Updated build process to include `.htaccess`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.drone.yml

<li>Added a command to move <code>.htaccess</code> to the build directory.<br> <li> Updated HMAC signature for the configuration.


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/369/files#diff-b54b39f1afced2465e1f3641db9d5bbf4f3a7fcf890996dfedd3c197bcb7f8c7">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.htaccess</strong><dd><code>Added rewrite rules for trailing slash redirection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

webserver/.htaccess

<li>Added rewrite rules to handle trailing slashes in asset URLs.<br> <li> Redirects URLs with trailing slashes to versions without slashes.


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/369/files#diff-309d53ad96143042bb4cf3e8141960a8e333a707f77474801c4df84cdce6352a">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>