### PR TITLE
Document dependency updates for PHP 8.4

### DIFF
--- a/migrations/52-53/index.md
+++ b/migrations/52-53/index.md
@@ -13,3 +13,6 @@ With the release of PHP 8.4, some new deprecations have been released like the [
 - [typo3/phar-stream-wrapper](https://github.com/joomla/joomla-cms/pull/44808) from version 3.1 to 4.0
 - [php-debugbar/php-debugbar](https://github.com/joomla/joomla-cms/pull/44806) from version 1.23 to 2.1
 - [wamania/php-stemmer](https://github.com/joomla/joomla-cms/pull/44657) from version 3.0 to 4.0
+- [algo26-matthias/idna-convert](https://github.com/joomla/joomla-cms/pull/45140) from version 3.1 to 4.0
+
+Beside the production dependencies are some developer dependencies also updated with [pr 45138](https://github.com/joomla/joomla-cms/pull/45138) which are needed for building or testing joomla.

--- a/migrations/52-53/index.md
+++ b/migrations/52-53/index.md
@@ -10,7 +10,6 @@ If you follow from the version of your current code until the version you want t
 ## Improved PHP 8.4 compatibility
 With the release of PHP 8.4, some new deprecations have been released like the [implicitly nullable parameter types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types). Beside fixing them in core, some dependency updates have been necessary to ensure perfect compatibility with the latest PHP feature version. The following major dependency updates have been done in this release:
 
-- [typo3/phar-stream-wrapper](https://github.com/joomla/joomla-cms/pull/44808) from version 3.1 to 4.0
 - [php-debugbar/php-debugbar](https://github.com/joomla/joomla-cms/pull/44806) from version 1.23 to 2.1
 - [wamania/php-stemmer](https://github.com/joomla/joomla-cms/pull/44657) from version 3.0 to 4.0
 - [algo26-matthias/idna-convert](https://github.com/joomla/joomla-cms/pull/45140) from version 3.1 to 4.0

--- a/migrations/52-53/index.md
+++ b/migrations/52-53/index.md
@@ -6,3 +6,10 @@ sidebar_position: 992
 
 An explanation of the code changes for each version of Joomla.
 If you follow from the version of your current code until the version you want to support you should come across all the changes you need to make.
+
+## Improved PHP 8.4 compatibility
+With the release of PHP 8.4, some new deprecations have been released like the [implicitly nullable parameter types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types). Beside fixing them in core, some dependency updates have been necessary to ensure perfect compatibility with the latest PHP feature version. The following major dependency updates have been done in this release:
+
+- [typo3/phar-stream-wrapper](https://github.com/joomla/joomla-cms/pull/44808) from version 3.1 to 4.0
+- [php-debugbar/php-debugbar](https://github.com/joomla/joomla-cms/pull/44806) from version 1.23 to 2.1
+- [wamania/php-stemmer](https://github.com/joomla/joomla-cms/pull/44657) from version 3.0 to 4.0


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Added documentation for PHP 8.4 compatibility improvements.

- Listed major dependency updates for PHP 8.4 support.

- Included links to relevant pull requests for reference.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.md</strong><dd><code>Added PHP 8.4 compatibility documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/52-53/index.md

<li>Added a section on PHP 8.4 compatibility improvements.<br> <li> Documented major dependency updates for PHP 8.4 support.<br> <li> Provided links to related pull requests for further details.


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/382/files#diff-87fd4e37a65fc1909280e37a6bf1b4f5125a4d680fc086df546be3fedbb11812">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>