### PR TITLE
Removing LegacyPropertyManagementTrait from Changelog class

### DIFF
--- a/migrations/64-70/compat-plugin.md
+++ b/migrations/64-70/compat-plugin.md
@@ -24,5 +24,5 @@ this type to ensure it loads before any other plugin, as this is critical for ba
 ### Detailed documentation
 
 :::warning[Reader Note]
-  Please read the [Compatibility Plugin 6.0](../54-60/compat-plugin.md) section
+  Please read the [Compatibility Plugin 6.0](../64-70/compat-plugin.md) section
 :::

--- a/migrations/64-70/compat-plugin.md
+++ b/migrations/64-70/compat-plugin.md
@@ -24,5 +24,5 @@ this type to ensure it loads before any other plugin, as this is critical for ba
 ### Detailed documentation
 
 :::warning[Reader Note]
-  Please read the [Compatibility Plugin 6.0](../64-70/compat-plugin.md) section
+  Please read the [Compatibility Plugin 7.0](../64-70/compat-plugin.md) section
 :::

--- a/migrations/64-70/compat-plugin.md
+++ b/migrations/64-70/compat-plugin.md
@@ -1,0 +1,28 @@
+---
+sidebar_position: 4
+---
+
+Compatibility Plugin
+====================
+
+:::tip[Developer Note]
+  Since this version of Joomla has not been released yet, this page can change anytime.
+:::
+
+:::warning[Developer Note]
+  Heads-up, don't create a plugin as `behaviour` plugin because it's possible that this group get removed at some point.
+:::
+
+## Joomla 7 Compatibility Plugin
+
+In Joomla! 7.0 the Compatibility Plugin introduced in Joomla! 6.0 will be replaced by a new plugin
+called "Behaviour - Backward Compatibility 7".
+
+Despite the warning about the potential removal of the `behaviour` plugin type, this compatibility plugin still uses
+this type to ensure it loads before any other plugin, as this is critical for backward compatibility functionality.
+
+### Detailed documentation
+
+:::warning[Reader Note]
+  Please read the [Compatibility Plugin 6.0](../54-60/compat-plugin.md) section
+:::

--- a/migrations/64-70/index.md
+++ b/migrations/64-70/index.md
@@ -1,6 +1,6 @@
 ---
 sidebar_position: 989
-title: 6.0 to 6.1
+title: 6.4 to 7.0
 ---
 
 Joomla 6.4 to 7.0 Upgrade Notes

--- a/migrations/64-70/index.md
+++ b/migrations/64-70/index.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 989
+title: 6.0 to 6.1
+---
+
+Joomla 6.4 to 7.0 Upgrade Notes
+===============================
+
+An explanation of the code changes for each version of Joomla.
+If you follow from the version of your current code until the version you want to support you should come across all the changes you need to make.

--- a/migrations/64-70/index.md
+++ b/migrations/64-70/index.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 989
+sidebar_position: 985
 title: 6.4 to 7.0
 ---
 

--- a/migrations/64-70/new-deprecations.md
+++ b/migrations/64-70/new-deprecations.md
@@ -1,0 +1,16 @@
+---
+sidebar_position: 2
+---
+
+New Deprecations
+================
+
+:::tip[Developer Note]
+  Since this version of Joomla has not been released yet, this page can change anytime.
+:::
+
+All the new deprecations that should be aware of and what you should now be using instead.
+
+:::tip[Reader Note]
+  No deprecations have been introduced in Joomla 6.1 yet
+:::

--- a/migrations/64-70/new-deprecations.md
+++ b/migrations/64-70/new-deprecations.md
@@ -12,5 +12,5 @@ New Deprecations
 All the new deprecations that should be aware of and what you should now be using instead.
 
 :::tip[Reader Note]
-  No deprecations have been introduced in Joomla 6.1 yet
+  No deprecations have been introduced in Joomla 7.0 yet
 :::

--- a/migrations/64-70/new-features.md
+++ b/migrations/64-70/new-features.md
@@ -1,0 +1,13 @@
+---
+sidebar_position: 1
+---
+
+New Features
+============
+
+:::tip[Developer Note]
+  Since this version of Joomla has not been released yet, this page can change anytime.
+:::
+
+All the new features that have been added to this version.
+Any changes in best practice.

--- a/migrations/64-70/removed-backward-incompatibility.md
+++ b/migrations/64-70/removed-backward-incompatibility.md
@@ -1,0 +1,10 @@
+---
+sidebar_position: 3
+---
+
+Removed and Backward Incompatibility
+====================================
+
+All the deprecated features that have now been removed and any backward incompatibilities.
+There should be an explanation of how to mitigate the removals / changes.
+

--- a/migrations/64-70/removed-backward-incompatibility.md
+++ b/migrations/64-70/removed-backward-incompatibility.md
@@ -8,3 +8,7 @@ Removed and Backward Incompatibility
 All the deprecated features that have now been removed and any backward incompatibilities.
 There should be an explanation of how to mitigate the removals / changes.
 
+### `Joomla\CMS\Changelog\Changelog` has been changed significantly
+
+- PR: https://github.com/joomla/joomla-cms/pull/44897
+- Description: The `Changelog` class was entirely depending on the `LegacyPropertyManagementTrait` and its `->get()` method. This is problematic because the `->get()` method circumvents the complete access protection in PHP and the trait itself is deprecated. In Joomla 6.0 the properties of the class have been mostly changed to public and can be accessed directly and the trait has been removed.


### PR DESCRIPTION
### **User description**
This is the documentation PR for https://github.com/joomla/joomla-cms/pull/44897

It depends on #589

___

### **PR Type**
Documentation


___

### **Description**
- Documented the removal of `LegacyPropertyManagementTrait` from `Changelog` class.

- Explained changes to property access in `Changelog` class.

- Highlighted the deprecation and replacement of the `->get()` method.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>removed-backward-incompatibility.md</strong><dd><code>Documented changes to `Changelog` class in Joomla 6.0</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/54-60/removed-backward-incompatibility.md

<li>Added documentation for changes in <code>Changelog</code> class.<br> <li> Explained removal of <code>LegacyPropertyManagementTrait</code>.<br> <li> Described new public property access approach.


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/388/files#diff-1b9f27ae2f64c35bc2cdba1c2988613e48b706934385a2e51f36e0e1bd2d23b2">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>