### PR TITLE
Remove HTMLHelper::Bootstrap('framework')

### DIFF
--- a/migrations/54-60/removed-backward-incompatibility.md
+++ b/migrations/54-60/removed-backward-incompatibility.md
@@ -322,9 +322,9 @@ Factory::getApplication()->bootComponent('actionlogs')->getMVCFactory()
   Extensions interacting with `#__ucm_history` may require schema or API updates.  
   **(more detail needed: schema differences and migration examples)**
 
-### HTMLHelper::Bootstrap('framwork') has been removed
+### HTMLHelper::Bootstrap('framework') has been removed
 
 - PR: https://github.com/joomla/joomla-cms/pull/44991
-- Description: The `HTMLHelper::Bootstrap('framwork')` as it was only kept for B/C purposes in the J4/5 versions. Developers should explicitly include **only** the components that are used in their layouts.
+- Description: The `HTMLHelper::Bootstrap('framework')` as it was only kept for B/C purposes in the J4/5 versions. Developers should explicitly include **only** the components that are used in their layouts.
 
 

--- a/migrations/54-60/removed-backward-incompatibility.md
+++ b/migrations/54-60/removed-backward-incompatibility.md
@@ -322,3 +322,9 @@ Factory::getApplication()->bootComponent('actionlogs')->getMVCFactory()
   Extensions interacting with `#__ucm_history` may require schema or API updates.  
   **(more detail needed: schema differences and migration examples)**
 
+### HTMLHelper::Bootstrap('framwork') has been removed
+
+- PR: https://github.com/joomla/joomla-cms/pull/44991
+- Description: The `HTMLHelper::Bootstrap('framwork')` as it was only kept for B/C purposes in the J4/5 versions. Developers should explicitly include **only** the components that are used in their layouts.
+
+


### PR DESCRIPTION
### **PR Type**
Documentation

related PR https://github.com/joomla/joomla-cms/pull/44991

___

### **Description**
- Documented the removal of `HTMLHelper::Bootstrap('framework')`.

- Provided a PR link and explanation for developers.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>removed-backward-incompatibility.md</strong><dd><code>Documented removal of `HTMLHelper::Bootstrap('framework')`</code></dd></summary>
<hr>

migrations/54-60/removed-backward-incompatibility.md

<li>Added a section documenting the removal of <br><code>HTMLHelper::Bootstrap('framework')</code>.<br> <li> Included a PR link for reference.<br> <li> Explained the reason for the removal and guidance for developers.


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/396/files#diff-1b9f27ae2f64c35bc2cdba1c2988613e48b706934385a2e51f36e0e1bd2d23b2">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>