### PR TITLE
Update calendar.md

### DIFF
--- a/docs/general-concepts/forms-fields/standard-fields/calendar.md
+++ b/docs/general-concepts/forms-fields/standard-fields/calendar.md
@@ -14,46 +14,22 @@ the text box. Otherwise the default value, if any, is displayed.
 - **name** (mandatory) is the unique name of the field.
 - **label** (mandatory) (translatable) is the field html label.
 - **description** (optional) (translatable) is the [field description](../standard-form-field-attributes.md#description).
-- **readonly** (optional) is whether the text box is read-only (true or false). If the text box is read-only, the date
-  cannot be changed, but can be selected and copied. No calendar icon will be shown.
-- **disabled** (optional) is whether the text box is disabled (true or false). If the text box is disabled, the date
-  cannot be changed, selected or copied.
+- **readonly** (optional) is whether the text box is read-only (true or false). If the text box is read-only, the date cannot be changed, but can be selected and copied. No calendar icon will be shown.
+- **disabled** (optional) is whether the text box is disabled (true or false). If the text box is disabled, the date cannot be changed, selected or copied.
 - **class** (optional) is a CSS class name for the HTML form field.
 - **format** (optional) is the date format to be used. This is in the format used by PHP to specify date string formats (see below). 
-If no format argument is given, '%Y-%m-%d' is assumed (giving dates like '2017-05-15'). 
-If showtime is true then you will need to include some time fields, for example, '%Y-%m-%d %H:%i:%s'.
-- **filter** (optional) is time zone to be used. There are two main values: "server_utc" and "user_utc". The first one is
-  server time zone and the later is user time zone as configured in global configuration and user information
-  respectively. There is also a value of none which must be used if the server time zone is set to something other than
-  UTC and showtime is false.
-- **translateformat** (optional) If set to true, the calendar will use the DATE_FORMAT_CALENDAR_DATE language key (if
-  showtime is true) or DATE_FORMAT_CALENDAR_DATETIME (if showtime is false) to determine the format. The format
-  attribute is ignored. If false, the format attribute is used but note that the
-  format string must include time fields for the time to be recorded. Defaults to false.
-- **showtime** (optional) If set to true and translateformat is true, the language key DATE_FORMAT_CALENDAR_DATETIME is
-  used, otherwise DATE_FORMAT_CALENDAR_DATE. Defaults to false.
-- **timeformat** (optional): can be set to 12 or 24. If set to 12, an additional selection is
-  available to the user to choose between AM and PM. This attribute does not affect how the date/time is saved. Defaults
-  to 24.
-- **singleheader** (optional): if set to false, the year and the month selection will be set on two separate lines,
-  with independent selection. Defaults to false.
-
-- **todaybutton** (optional): if set to true, a button is added at the bottom of the date picker to select the date of
-  the current day. Defaults to true.
-
-- **weeknumbers** (optional): if set to true, a column is added at the left of the date picker to display the number of
-  the week in the current year. Defaults to true.
-
-- **filltable** (optional): if set to true, dates of the previous and next month are added at the top and bottom of the
-  current month to fill the grid. Defaults to true.
-
-- **minyear** (optional): set a signed integer for a number of years (-10, -2, 0, 7, 12, ...) to define the relative
-  lower limit for the year selection. The user cannot select a year before this limit. If zero,
-  which is the default, there is no limit.
-
-- **maxyear** (optional): set a signed integer for a number of years (-10, -2, 0, 7, 12, ...) to define the relative
-  upper limit for the year selection. The user cannot select a year after this limit. If zero,
-  which is the default, there is no limit.
+  - If no format argument is given, '%Y-%m-%d' is assumed (giving dates like '2017-05-15'). 
+  - If showtime is true then you will need to include some time fields, for example, '%Y-%m-%d %H:%i:%s'.
+- **filter** (optional) is time zone to be used. There are two main values: "server_utc" and "user_utc". The first one is server time zone and the later is user time zone as configured in global configuration and user information respectively. There is also a value of none which must be used if the server time zone is set to something other than UTC and showtime is false.
+- **translateformat** (optional) If set to true, the calendar will use the DATE_FORMAT_CALENDAR_DATE language key (if showtime is true) or DATE_FORMAT_CALENDAR_DATETIME (if showtime is false) to determine the format. The format attribute is ignored. If false, the format attribute is used but note that the format string must include time fields for the time to be recorded. Defaults to false.
+- **showtime** (optional) If set to true and translateformat is true, the language key DATE_FORMAT_CALENDAR_DATETIME is used, otherwise DATE_FORMAT_CALENDAR_DATE. Defaults to false.
+- **timeformat** (optional): can be set to 12 or 24. If set to 12, an additional selection is available to the user to choose between AM and PM. This attribute does not affect how the date/time is saved. Defaults to 24.
+- **singleheader** (optional): if set to false, the year and the month selection will be set on two separate lines, with independent selection. Defaults to false.
+- **todaybutton** (optional): if set to true, a button is added at the bottom of the date picker to select the date of the current day. Defaults to true.
+- **weeknumbers** (optional): if set to true, a column is added at the left of the date picker to display the number of the week in the current year. Defaults to true.
+- **filltable** (optional): if set to true, dates of the previous and next month are added at the top and bottom of the current month to fill the grid. Defaults to true.
+- **minyear** (optional): set a signed integer for a number of years (-10, -2, 0, 7, 12, ...) to define the relative lower limit for the year selection. The user cannot select a year before this limit. If zero, which is the default, there is no limit.
+- **maxyear** (optional): set a signed integer for a number of years (-10, -2, 0, 7, 12, ...) to define the relative upper limit for the year selection. The user cannot select a year after this limit. If zero, which is the default, there is no limit.
 
 Implemented by: libraries/src/Form/Field/CalendarField.php
 


### PR DESCRIPTION
Blank lines in the unordered list causes the entire list to appear double spaced. I have taken out the blank lines, added a sub-list to improve readability and removed line breaks within the list - that may help improve translation.