### PR TITLE
Tab-state script removed

### DIFF
--- a/migrations/54-60/removed-backward-incompatibility.md
+++ b/migrations/54-60/removed-backward-incompatibility.md
@@ -168,3 +168,9 @@ if ($app instanceof \Joomla\CMS\Application\ConsoleApplication) {
   - `\Joomla\CMS\MVC\Controller\ApiController` uses a `Registry` object for the model state.
   - `\Joomla\CMS\User\UserHelper::getProfile()` returns a `stdClass` object now.
 
+### Legacy/outdated static assets removed
+
+- Tab state
+	- File removed: build/media_source/legacy/js/tabs-state.es5.js
+	- PR: https://github.com/joomla/joomla-cms/pull/45021
+ 


### PR DESCRIPTION
### **User description**
PR: https://github.com/joomla/joomla-cms/pull/45021


___

### **PR Type**
Documentation


___

### **Description**
- Documented the removal of legacy tab-state script.

- Added details about the removed file and related PR.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>removed-backward-incompatibility.md</strong><dd><code>Documented removal of legacy tab-state script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/54-60/removed-backward-incompatibility.md

<li>Added a section about removed legacy/outdated static assets.<br> <li> Documented the removal of <code>tabs-state.es5.js</code>.<br> <li> Included reference to the related PR.


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/414/files#diff-1b9f27ae2f64c35bc2cdba1c2988613e48b706934385a2e51f36e0e1bd2d23b2">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>