### PR TITLE
Deprecate TYPO3/phar-stream-wrapper

### DIFF
--- a/migrations/52-53/new-deprecations.md
+++ b/migrations/52-53/new-deprecations.md
@@ -60,3 +60,8 @@ PR: https://github.com/joomla/joomla-cms/pull/43396
 
 Deprecate the namespace property of the ComponentRecord class. The property were never initialised.
 PR: https://github.com/joomla/joomla-cms/pull/44754
+
+## Dependency Deprecations
+
+### TYPO3/phar-stream-wrapper
+PHP 7 had a security issue with .phar packages. To circumvent the issue, the TYPO3 project created this wrapper. In PHP 8.0 this has been fixed in PHP and the whole wrapper is not needed anymore. This package will be removed in 6.0.


### PR DESCRIPTION
### **User description**
This is the docs PR for this CMS PR: https://github.com/joomla/joomla-cms/pull/45255


___

### **PR Type**
Documentation


___

### **Description**
- Documented deprecation of `TYPO3/phar-stream-wrapper` dependency.

- Explained the reason for deprecation and its removal timeline.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>new-deprecations.md</strong><dd><code>Added documentation for `TYPO3/phar-stream-wrapper` deprecation</code></dd></summary>
<hr>

migrations/52-53/new-deprecations.md

<li>Added a new section for dependency deprecations.<br> <li> Documented the deprecation of <code>TYPO3/phar-stream-wrapper</code>.<br> <li> Explained the security issue in PHP 7 and resolution in PHP 8.<br> <li> Noted removal of the package in version 6.0.


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/436/files#diff-82a888d27253cf55ea68c1f5d1e4ea01494a58a19b94d0ffb845c8f81d2141aa">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>