### PR TITLE
Removing TYPO3/phar-stream-wrapper

### DIFF
--- a/migrations/54-60/removed-backward-incompatibility.md
+++ b/migrations/54-60/removed-backward-incompatibility.md
@@ -218,3 +218,7 @@ if ($app instanceof \Joomla\CMS\Application\ConsoleApplication) {
 - Folder: libraries/src/Filesystem
 - Description: The Filesystem package of the CMS (`\Joomla\CMS\Filesystem`) has been deprecated for a long time. For Joomla 6.0 it has been moved to the compat plugin and will finally be completely removed in 7.0. Please use the [framework `Filesystem`](https://github.com/joomla-framework/filesystem) package (`\Joomla\Filesystem`). The packages can be used nearly interchangeably, with the exception of `File::exists()` and `Folder::exists()`. Please use `is_file()` and `is_dir()` directly.
 
+### TYPO3/phar-stream-wrapper
+
+- PR: https://github.com/joomla/joomla-cms/pull/45256
+- Description: The TYPO3/phar-stream-wrapper dependency fixes a security issue in PHP 7, which has been fixed in PHP 8.0. This means that this package isn't necessary at all in Joomla and can be removed entirely.


### PR DESCRIPTION
### **User description**
This is the documentation PR for https://github.com/joomla/joomla-cms/pull/45256


___

### **PR Type**
Documentation


___

### **Description**
- Documented the removal of `TYPO3/phar-stream-wrapper` dependency.

- Explained the security context and PHP version relevance.

- Linked the related PR for further reference.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>removed-backward-incompatibility.md</strong><dd><code>Added documentation for `TYPO3/phar-stream-wrapper` removal</code></dd></summary>
<hr>

migrations/54-60/removed-backward-incompatibility.md

<li>Added a section documenting the removal of <code>TYPO3/phar-stream-wrapper</code>.<br> <li> Provided a description of its security context and relevance to PHP <br>versions.<br> <li> Included a link to the related PR for additional details.


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/437/files#diff-1b9f27ae2f64c35bc2cdba1c2988613e48b706934385a2e51f36e0e1bd2d23b2">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>