### PR TITLE
Add removed helper files

### DIFF
--- a/migrations/54-60/removed-backward-incompatibility.md
+++ b/migrations/54-60/removed-backward-incompatibility.md
@@ -101,7 +101,6 @@ if ($this->item->created !== null) {
 }
 ```
 
-
 ### None namespaced indexer file removed
 
 - PR: https://github.com/joomla/joomla-cms/pull/44646
@@ -136,7 +135,6 @@ $app = $this->getApplication();
 - PR: https://github.com/joomla/joomla-cms/pull/44662
 - File: libraries/src/Form/FormRule.php
 - Description: The `FormRule` class has a deprecated `JCOMPAT_UNICODE_PROPERTIES` constant which is not used anymore and got removed without a replacement. If the constant is still be used in an extension, copy the code from the FormRule class to your extension.
-
 
 ### createThumbs function got removed from the image class
 
@@ -181,7 +179,6 @@ if ($app instanceof \Joomla\CMS\Application\ConsoleApplication) {
 - Tab state
 	- File removed: build/media_source/legacy/js/tabs-state.es5.js
 	- PR: https://github.com/joomla/joomla-cms/pull/45021
- 
 
 ### CMS Filesystem Package got moved to the compat plugin
 
@@ -193,3 +190,32 @@ if ($app instanceof \Joomla\CMS\Application\ConsoleApplication) {
 
 - PR: https://github.com/joomla/joomla-cms/pull/45256
 - Description: The TYPO3/phar-stream-wrapper dependency fixes a security issue in PHP 7, which has been fixed in PHP 8.0. This means that this package isn't necessary at all in Joomla and can be removed entirely.
+
+### None namespaced helper classes got removed
+
+- PR: https://github.com/joomla/joomla-cms/pull/45339
+- Files:
+  - administrator/components/com_banners/helpers/banners.php
+  - administrator/components/com_categories/helpers/categories.php
+  - administrator/components/com_contact/helpers/contact.php
+  - administrator/components/com_content/helpers/content.php
+  - administrator/components/com_contenthistory/helpers/contenthistory.php
+  - administrator/components/com_fields/helpers/fields.php
+  - administrator/components/com_finder/helpers/language.php
+  - administrator/components/com_installer/helpers/installer.php
+  - administrator/components/com_media/helpers/media.php
+  - administrator/components/com_menus/helpers/menus.php
+  - administrator/components/com_modules/helpers/modules.php
+  - administrator/components/com_newsfeeds/helpers/newsfeeds.php
+  - administrator/components/com_plugins/helpers/plugins.php
+  - administrator/components/com_redirect/helpers/redirect.php
+  - administrator/components/com_templates/helpers/template.php
+  - administrator/components/com_templates/helpers/templates.php
+  - administrator/components/com_users/helpers/debug.php
+  - administrator/components/com_users/helpers/users.php
+  - components/com_contact/helpers/route.php
+  - components/com_content/helpers/icon.php
+  - components/com_finder/helpers/route.php
+  - components/com_newsfeeds/helpers/route.php
+  - components/com_tags/helpers/route.php
+- Description: The files are legacy helper files which got replaced by a namespaced one and where there for backwards compatibility reasons. The namespaced ones should be used instead.


### PR DESCRIPTION
### **User description**
For https://github.com/joomla/joomla-cms/pull/45339


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Documented the removal of non-namespaced helper classes.

- Added details about legacy helper files replaced by namespaced ones.

- Cleaned up unnecessary blank lines in the migration documentation.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>removed-backward-incompatibility.md</strong><dd><code>Documented removal of legacy helper files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/54-60/removed-backward-incompatibility.md

<li>Added section documenting removal of non-namespaced helper classes.<br> <li> Listed legacy helper files replaced by namespaced ones.<br> <li> Removed unnecessary blank lines for better readability.


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/440/files#diff-1b9f27ae2f64c35bc2cdba1c2988613e48b706934385a2e51f36e0e1bd2d23b2">+28/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>