### PR TITLE
Remove CMS DB aware trait

### DIFF
--- a/migrations/54-60/removed-backward-incompatibility.md
+++ b/migrations/54-60/removed-backward-incompatibility.md
@@ -193,3 +193,9 @@ if ($app instanceof \Joomla\CMS\Application\ConsoleApplication) {
 
 - PR: https://github.com/joomla/joomla-cms/pull/45256
 - Description: The TYPO3/phar-stream-wrapper dependency fixes a security issue in PHP 7, which has been fixed in PHP 8.0. This means that this package isn't necessary at all in Joomla and can be removed entirely.
+
+### CMS DatabaseAwareTrait class got removed
+
+- PR: https://github.com/joomla/joomla-cms/pull/45340
+- File: libraries/src/MVC/Model/DatabaseAwareTrait.php
+- Description: The trait `Joomla\Database\DatabaseAwareTrait` should be used instead as they both contain the same functionality.


### PR DESCRIPTION
### **User description**
For https://github.com/joomla/joomla-cms/pull/45340


___

### **PR Type**
documentation


___

### **Description**
- Documented the removal of `CMS DatabaseAwareTrait` class.

- Suggested using `Joomla\Database\DatabaseAwareTrait` as a replacement.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>removed-backward-incompatibility.md</strong><dd><code>Documented removal of CMS DatabaseAwareTrait class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/54-60/removed-backward-incompatibility.md

<li>Added a note about the removal of <code>CMS DatabaseAwareTrait</code>.<br> <li> Provided a replacement suggestion with <br><code>Joomla\Database\DatabaseAwareTrait</code>.<br> <li> Linked the relevant PR for reference.


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/441/files#diff-1b9f27ae2f64c35bc2cdba1c2988613e48b706934385a2e51f36e0e1bd2d23b2">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>