### PR TITLE
Add chapter for buildVotingQuery removal

### DIFF
--- a/migrations/54-60/removed-backward-incompatibility.md
+++ b/migrations/54-60/removed-backward-incompatibility.md
@@ -193,3 +193,9 @@ if ($app instanceof \Joomla\CMS\Application\ConsoleApplication) {
 
 - PR: https://github.com/joomla/joomla-cms/pull/45256
 - Description: The TYPO3/phar-stream-wrapper dependency fixes a security issue in PHP 7, which has been fixed in PHP 8.0. This means that this package isn't necessary at all in Joomla and can be removed entirely.
+
+### buildVotingQuery function in QueryHelper got removed
+
+- PR: https://github.com/joomla/joomla-cms/pull/45389
+- File: components/com_content/src/Helper/QueryHelper.php
+- Description: The `buildVotingQuery` is not used in core. If the extension needs that functionality, copy it from the 5.3 branch.


### PR DESCRIPTION
### **User description**
https://github.com/joomla/joomla-cms/pull/45389


___

### **PR Type**
Documentation


___

### **Description**
- Add documentation for removal of `buildVotingQuery` function

- Reference affected file and migration guidance for extensions


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>removed-backward-incompatibility.md</strong><dd><code>Add migration note for buildVotingQuery removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/54-60/removed-backward-incompatibility.md

<li>Added a new section about the removal of <code>buildVotingQuery</code> from <br><code>QueryHelper</code><br> <li> Provided PR link, affected file, and migration advice for extensions


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/447/files#diff-1b9f27ae2f64c35bc2cdba1c2988613e48b706934385a2e51f36e0e1bd2d23b2">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>