### PR TITLE
Remove tfa property from login view

### DIFF
--- a/migrations/54-60/removed-backward-incompatibility.md
+++ b/migrations/54-60/removed-backward-incompatibility.md
@@ -199,3 +199,9 @@ if ($app instanceof \Joomla\CMS\Application\ConsoleApplication) {
 - PR: https://github.com/joomla/joomla-cms/pull/45389
 - File: components/com_content/src/Helper/QueryHelper.php
 - Description: The `buildVotingQuery` is not used in core. If the extension needs that functionality, copy it from the 5.3 branch.
+
+### tfa property in login view got removed
+
+- PR: https://github.com/joomla/joomla-cms/pull/45399
+- File: components/com_users/src/View/Login/HtmlView.php
+- Description: The `tfa` is not used in the login view anymore as it is a leftover from the old two factor authentication system.


### PR DESCRIPTION
### **User description**
https://github.com/joomla/joomla-cms/pull/45399


___

### **PR Type**
documentation


___

### **Description**
- Document removal of `tfa` property from login view

- Add backward incompatibility note for `tfa` removal


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>removed-backward-incompatibility.md</strong><dd><code>Add migration note for removal of `tfa` property in login view</code></dd></summary>
<hr>

migrations/54-60/removed-backward-incompatibility.md

<li>Added a section documenting the removal of the <code>tfa</code> property from the <br>login view.<br> <li> Provided PR reference, affected file, and description for context.


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/451/files#diff-1b9f27ae2f64c35bc2cdba1c2988613e48b706934385a2e51f36e0e1bd2d23b2">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>