### PR TITLE
Remove the static getLogContentTypeParams function

### DIFF
--- a/migrations/54-60/removed-backward-incompatibility.md
+++ b/migrations/54-60/removed-backward-incompatibility.md
@@ -242,3 +242,18 @@ $table = new \Joomla\CMS\Table\Content($db);
 - PR: https://github.com/joomla/joomla-cms/pull/45425
 - File: libraries/src/Application/WebApplication.php
 - Description: The `$item_associations` was added to the `WebApplication` class for improved PHP 8.2 compatibility and is not used at all.
+
+### getLogContentTypeParams of the ActionlogsHelper got removed
+
+- PR: https://github.com/joomla/joomla-cms/pull/45434
+- File: administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+- Description: The `getLogContentTypeParams` function in the the `ActionlogsHelper` class got removed as the one in the model should be used:
+
+```php
+// Old:
+ActionlogsHelper::getLogContentTypeParams('context');
+
+// New:
+Factory::getApplication()->bootComponent('actionlogs')->getMVCFactory()
+    ->createModel('ActionlogConfig', 'Administrator')->getLogContentTypeParams('context');
+```


### PR DESCRIPTION
### **User description**
https://github.com/joomla/joomla-cms/pull/45434


___

### **PR Type**
documentation


___

### **Description**
- Document removal of `getLogContentTypeParams` from `ActionlogsHelper`

- Provide migration instructions for affected code

- Update backward incompatibility notes for developers


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>removed-backward-incompatibility.md</strong><dd><code>Add documentation for removed ActionlogsHelper method</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/54-60/removed-backward-incompatibility.md

<li>Added section documenting removal of <code>getLogContentTypeParams</code> from <br><code>ActionlogsHelper</code><br> <li> Provided code migration example from old to new usage<br> <li> Linked relevant PR and file for reference


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/459/files#diff-1b9f27ae2f64c35bc2cdba1c2988613e48b706934385a2e51f36e0e1bd2d23b2">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>