### PR TITLE
Update insert-data example to fix errors

### DIFF
--- a/versioned_docs/version-5.3/general-concepts/database/insert-data.md
+++ b/versioned_docs/version-5.3/general-concepts/database/insert-data.md
@@ -68,10 +68,10 @@ $query
 
 // Bind values
 $query
-    ->bind(':user_id', 1001, Joomla\Database\ParameterType::INTEGER)
+    ->bind(':user_id', $db->quote(1001), \Joomla\Database\ParameterType::INTEGER)
     ->bind(':profile_key', 'custom.message')
     ->bind(':profile_value', 'Inserting a record using insert()')
-    ->bind(':ordering', 1, Joomla\Database\ParameterType::INTEGER);
+    ->bind(':ordering', $db->quote(1), \Joomla\Database\ParameterType::INTEGER);
 
 // Set the query using our newly populated query object and execute it.
 $db->setQuery($query);


### PR DESCRIPTION
If we run this code example, it will return errors.

## Bind issue with integer
Since we are not handing a variable but an integer, it generates `Fatal error: Cannot pass parameter 2 by reference`

Instead of:
```
$query
    ->bind(':user_id', 1001, Joomla\Database\ParameterType::INTEGER)
```

better:
```
$user_id = 1001;

$query
    ->bind(':user_id', $user_id, \Joomla\Database\ParameterType::INTEGER)
```

## Namespace issue
And ParameterType is not found as not backslashed.

Should be (proposed solution): 
```
$query
    ->bind(':user_id', $db->quote(1001), \Joomla\Database\ParameterType::INTEGER)
```
or:  
```
use Joomla\Database\ParameterType;

[...]

$query
    ->bind(':user_id', $db->quote(1001), ParameterType::INTEGER)
```

Other places in the manual can also be adjusted.