### PR TITLE
migrations/51-52 Remove not-released-yet notice

### DIFF
--- a/migrations/51-52/new-features.md
+++ b/migrations/51-52/new-features.md
@@ -4,10 +4,6 @@ sidebar_position: 1
 
 # New features
 
-:::tip[Developer Note]
-  Since this version of Joomla has not been released yet, this page can change anytime.
-:::
-
 All the new features that have been added to this version.
 Any changes in best practice.
 


### PR DESCRIPTION
### **PR Type**
documentation


___

### **Description**
- Removed "not released yet" developer notice from migration documentation.

- Clarified that the page lists new features and best practices.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>new-features.md</strong><dd><code>Removed unreleased version notice from documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/51-52/new-features.md

<li>Deleted developer tip about unreleased version status.<br> <li> Retained focus on new features and best practices.


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/468/files#diff-c9cf512d274255590a3c0d7048db6c59ebf526c4d91b6e3fcf073745efab7746">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>