### PR TITLE
Update status.md

### DIFF
--- a/docs/general-concepts/forms-fields/standard-fields/status.md
+++ b/docs/general-concepts/forms-fields/standard-fields/status.md
@@ -11,6 +11,8 @@ The **status** form field type provides a list box of statuses. This field exten
 - **description** (optional) (translatable) is the [field description](../standard-form-field-attributes.md#description).
 - **multiple** (optional) if set to true allows multiple items to be selected at the same time. Set to false to allow single selection.
 - **required** (optional) if set to true, the first field option should be empty, see last example.
+- **optionsFilter** (optional) Comma-separated list of values to be displayed.
+- **class** (optional) add the classname `form-select-color-state` to add color feedback for the selected state.
 
 Implemented by: libraries/src/Form/Field/StatusField.php
 
@@ -25,9 +27,29 @@ Implemented by: libraries/src/Form/Field/StatusField.php
 />
 ```
 
-Based on the source code this returns the following entries in a list:  
-Trashed - JTRASHED  
-Disabled - JDISABLED    
-Enabled - JENABLED  
-Archived - JARCHIVED  
-All - JALL
+## Available options
+Based on the source code this returns the following entries in a list: 
+
+| Value | Text         |
+| ----- | ------------ |
+| -2    | JTRASHED     |
+| 0     | JUNPUBLISHED |
+| 1     | JPUBLISHED   |
+| 2     | JARCHIVED    |
+| *     | JALL         |
+
+## Filter options
+If this field is used in the element context and not as a filter, the *All* option is not required, for example.
+In such a case, the **optionsFilter** attribute can be used to select which options should be selectable.
+
+```xml
+<field
+        name="mystatus" 
+        type="status"
+        label="Choose" 
+        description=""
+        optionsFilter="0,1"
+/>
+```
+
+The field now only loads the options JPUBLISHED and JUNPUBLISHED.


### PR DESCRIPTION
### **User description**
Added missing information about the optionsFilter and corrected information about the options that are loaded


___

### **PR Type**
Documentation


___

### **Description**
- Added detailed explanation for `optionsFilter` attribute.

- Corrected and expanded the list of available status options.

- Provided example usage for filtering options.

- Clarified behavior of options in different contexts.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>status.md</strong><dd><code>Expanded and clarified status field documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/general-concepts/forms-fields/standard-fields/status.md

<li>Added description for <code>optionsFilter</code> and <code>class</code> attributes.<br> <li> Replaced plain list of options with a detailed table.<br> <li> Added section and example for filtering options using <code>optionsFilter</code>.<br> <li> Clarified context-specific behavior for available options.


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/475/files#diff-b66feb0994ca303c8fd78b832d7cc4132909ce3eedf333e97b545fe9c64be2c1">+28/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>