### PR TITLE
Add removal of com_search methods from Language

### DIFF
--- a/migrations/54-60/removed-backward-incompatibility.md
+++ b/migrations/54-60/removed-backward-incompatibility.md
@@ -258,3 +258,20 @@ ActionlogsHelper::getLogContentTypeParams('context');
 Factory::getApplication()->bootComponent('actionlogs')->getMVCFactory()
     ->createModel('ActionlogConfig', 'Administrator')->getLogContentTypeParams('context');
 ```
+
+## Removal of old `com_search`-related methods from Language class
+- PR: https://github.com/joomla/joomla-cms/pull/42892
+- File: libraries/src/Language/Language.php
+- Description: The `\Joomla\CMS\Language\Language` class contained special methods for the old `com_search` component, which should have been removed in 4.0. These methods are removed without replacement. The following methods have been removed:
+  - `getIgnoredSearchWords()`
+  - `getIgnoredSearchWordsCallback()`
+  - `setIgnoredSearchWordsCallback()`
+  - `getLowerLimitSearchWord()`
+  - `getLowerLimitSearchWordCallback()`
+  - `setLowerLimitSearchWordCallback()`
+  - `getUpperLimitSearchWord()`
+  - `getUpperLimitSearchWordCallback()`
+  - `setUpperLimitSearchWordCallback()`
+  - `getSearchDisplayedCharactersNumber()`
+  - `getSearchDisplayedCharactersNumberCallback()`
+  - `setSearchDisplayedCharactersNumberCallback()`


### PR DESCRIPTION
### **User description**
This is the documentation PR for https://github.com/joomla/joomla-cms/pull/42892


___

### **PR Type**
Documentation


___

### **Description**
• Document removal of deprecated `com_search` methods from Language class
• Add backward incompatibility notice for migration guide


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>removed-backward-incompatibility.md</strong><dd><code>Document com_search method removals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/54-60/removed-backward-incompatibility.md

• Added section documenting removal of 10 deprecated <br><code>com_search</code>-related methods<br> • Listed all removed methods with their <br>names and purpose<br> • Included PR reference and file location for <br>context


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/482/files#diff-1b9f27ae2f64c35bc2cdba1c2988613e48b706934385a2e51f36e0e1bd2d23b2">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>