### PR TITLE
Add deprecation of UCM system

### DIFF
--- a/migrations/53-54/new-deprecations.md
+++ b/migrations/53-54/new-deprecations.md
@@ -11,6 +11,21 @@ New Deprecations
 
 All the new deprecations you should be aware of — and what you should use instead.
 
+## Class deprecations
+
+Planned to be removed in Joomla! 7.0.
+
+### Deprecation of UCM system
+In Joomla 3.2, the `Unified Content Model` was introduced, which was supposed to be a universal system for all content in Joomla. The concept turned out to be not viable and the remnants of this have now been deprecated for removal in Joomla 7.0. The following classes have been deprecated without replacement:
+
+- `Joomla\CMS\Table\Ucm`
+- `Joomla\CMS\UCM\UCM`
+- `Joomla\CMS\UCM\UCMBase`
+- `Joomla\CMS\UCM\UCMContent`
+- `Joomla\CMS\UCM\UCMType`
+
+Related PR: https://github.com/joomla/joomla-cms/pull/44910
+
 ## Deprecation of `registerListeners()`
 [43395](https://github.com/joomla/joomla-cms/pull/43395) – CMSPlugin: deprecation for registerListeners
 


### PR DESCRIPTION
### **User description**
This is the documentation PR for https://github.com/joomla/joomla-cms/pull/44910


___

### **PR Type**
Documentation


___

### **Description**
• Document deprecation of UCM (Unified Content Model) system classes
• Add migration guide for Joomla 5.3-5.4 version upgrade
• Reference related implementation PR for UCM deprecation


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>new-deprecations.md</strong><dd><code>Add UCM system deprecation documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/53-54/new-deprecations.md

• Add new "Class deprecations" section for UCM system<br> • Document 5 <br>deprecated UCM classes without replacement<br> • Include explanation of <br>UCM concept failure and removal timeline<br> • Reference related <br>implementation PR link


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/484/files#diff-bbc8f111403603cb8a23812e5045473bd44f59ef022624fc8567e2a8b672d0e4">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>