### PR TITLE
Add removal of LegacyPropertyManagementTrait from MVC

### DIFF
--- a/migrations/54-60/removed-backward-incompatibility.md
+++ b/migrations/54-60/removed-backward-incompatibility.md
@@ -69,6 +69,21 @@ echo $article->title;
   - https://github.com/joomla/joomla-cms/pull/42890
 - Description: The CMS Input namespace `\Joomla\CMS\Input` has been removed. The CMS core code has switched the code to the Framework Input library with the namespace `\Joomla\Input`, which is very much a drop-in replacement. This is especially of relevance if you are using the MVC classes, which now use the framework class. Make sure that your code imports the correct class.
 
+## Removed `LegacyPropertyManagementTrait` from MVC classes
+
+- PR: https://github.com/joomla/joomla-cms/pull/44907
+- Description: The models and views of the Joomla MVC used the `LegacyPropertyManagementTrait` with the generic `set()` and `get()` methods. Since the trait is deprecated, its usage in the Joomla core is removed where possible. This affects all models and views, which will not contain a generic `set()` method anymore and in the case of the models also no generic `get()` method. You should instead write to the attributes directly. The views still contain a `get()` method, since that is overridden by the view class itself.
+
+```php
+// Old:
+$this->set('key', 'value');
+$var = $this->get('key', 'defaultValue');
+
+// New:
+$this->key = 'value';
+$var = $this->key ?? 'defaultValue';
+```
+
 ## UTC Used Instead of GMT
 
 - PR: https://github.com/joomla/joomla-cms/pull/43912


### PR DESCRIPTION
### **User description**
This is the documentation PR for https://github.com/joomla/joomla-cms/pull/44907


___

### **PR Type**
Documentation


___

### **Description**
- Document removal of `LegacyPropertyManagementTrait` from MVC classes

- Add migration guide for deprecated `set()` and `get()` methods

- Provide code examples for property access changes


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>removed-backward-incompatibility.md</strong><dd><code>Document MVC trait removal migration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/54-60/removed-backward-incompatibility.md

<li>Add new section documenting <code>LegacyPropertyManagementTrait</code> removal<br> <li> Include migration examples from generic methods to direct property <br>access<br> <li> Reference related PR #44907 for implementation details


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/486/files#diff-1b9f27ae2f64c35bc2cdba1c2988613e48b706934385a2e51f36e0e1bd2d23b2">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>