### PR TITLE
Extend support for deprecated Plugins, Editor, Captcha. For pr 45818 and 45819

### DIFF
--- a/migrations/53-54/new-deprecations.md
+++ b/migrations/53-54/new-deprecations.md
@@ -45,6 +45,18 @@ Related PR: [44910](https://github.com/joomla/joomla-cms/pull/44910) – Depreca
 - ❌ `registerListeners()` is deprecated in both `Joomla\CMS\Extension\PluginInterface` and `Joomla\CMS\Plugin\CMSPlugin`.
   - ✅ Instead, implement the `SubscriberInterface`. The method is no longer required in this case.
 
+### Support for deprecated event API were extended from Joomla 6 to Joomla 7.
+
+[45818](https://github.com/joomla/joomla-cms/pull/45818) Support for deprecated event API were extended from Joomla 6 to Joomla 7.
+Support for events without event class will be stoped in Joomla 7 instead of Joomla 6.
+
+### Support for deprecated Editor and Captcha API were extended from Joomla 6 to Joomla 7.
+[45819](https://github.com/joomla/joomla-cms/pull/45819) Support for deprecated Editor and Captcha API were extended from Joomla 6 to Joomla 7.
+Links for an examples with new API:
+ - [Editors Plugin](/docs/building-extensions/plugins/plugin-examples/editors-plugin/)
+ - [Editors Buttons (XTD) Plugin](/docs/building-extensions/plugins/plugin-examples/editors-xtd-plugin/)
+ - [Captcha Plugin](/docs/building-extensions/plugins/plugin-examples/captcha-plugin/)
+
 ### Deprecation of `$_db`, `getDbo()`, and `setDbo()`
 [45165](https://github.com/joomla/joomla-cms/pull/45165) – Replace table _db with DatabaseAwareTrait
 
@@ -56,6 +68,8 @@ Related PR: [44910](https://github.com/joomla/joomla-cms/pull/44910) – Depreca
     $db = $this->getDatabase();
     $this->setDatabase($db);
     ```
+
+
 
 ## Language String Deprecation
 

--- a/migrations/53-54/new-deprecations.md
+++ b/migrations/53-54/new-deprecations.md
@@ -45,18 +45,17 @@ Related PR: [44910](https://github.com/joomla/joomla-cms/pull/44910) – Depreca
 - ❌ `registerListeners()` is deprecated in both `Joomla\CMS\Extension\PluginInterface` and `Joomla\CMS\Plugin\CMSPlugin`.
   - ✅ Instead, implement the `SubscriberInterface`. The method is no longer required in this case.
 
-### Support for deprecated event API were extended from Joomla 6 to Joomla 7.
+### Support for the deprecated event API was extended from Joomla 6 to Joomla 7.
 
-[45818](https://github.com/joomla/joomla-cms/pull/45818) Support for deprecated event API were extended from Joomla 6 to Joomla 7.
-Support for events without event class will be stoped in Joomla 7 instead of Joomla 6.
+[45818](https://github.com/joomla/joomla-cms/pull/45818): Support for the deprecated event API was extended from Joomla 6 to Joomla 7.
+Support for events without an event class will be stopped in Joomla 7 instead of Joomla 6.
 
-### Support for deprecated Editor and Captcha API were extended from Joomla 6 to Joomla 7.
-[45819](https://github.com/joomla/joomla-cms/pull/45819) Support for deprecated Editor and Captcha API were extended from Joomla 6 to Joomla 7.
-Links for an examples with new API:
+### Support for the deprecated Editor and Captcha APIs was extended from Joomla 6 to Joomla 7.
+[45819](https://github.com/joomla/joomla-cms/pull/45819): Support for the deprecated Editor and Captcha APIs was extended from Joomla 6 to Joomla 7.
+Example implementations using the new APIs:
  - [Editors Plugin](/docs/building-extensions/plugins/plugin-examples/editors-plugin/)
  - [Editors Buttons (XTD) Plugin](/docs/building-extensions/plugins/plugin-examples/editors-xtd-plugin/)
  - [Captcha Plugin](/docs/building-extensions/plugins/plugin-examples/captcha-plugin/)
-
 ### Deprecation of `$_db`, `getDbo()`, and `setDbo()`
 [45165](https://github.com/joomla/joomla-cms/pull/45165) – Replace table _db with DatabaseAwareTrait
 


### PR DESCRIPTION
### **User description**
For pr :
- https://github.com/joomla/joomla-cms/pull/45818
- https://github.com/joomla/joomla-cms/pull/45819


___

### **PR Type**
Documentation


___

### **Description**
- Extended deprecation timeline for event API from Joomla 6 to 7

- Extended deprecation timeline for Editor and Captcha API from Joomla 6 to 7

- Added documentation links for new API examples


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Deprecated APIs"] --> B["Timeline Extended"]
  B --> C["Joomla 6 → Joomla 7"]
  C --> D["Event API"]
  C --> E["Editor API"]
  C --> F["Captcha API"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>new-deprecations.md</strong><dd><code>Extended API deprecation timelines documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/53-54/new-deprecations.md

<ul><li>Added section documenting event API deprecation timeline extension<br> <li> Added section documenting Editor and Captcha API deprecation timeline <br>extension<br> <li> Included links to new API documentation examples<br> <li> Added minor formatting with extra blank lines</ul>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/493/files#diff-bbc8f111403603cb8a23812e5045473bd44f59ef022624fc8567e2a8b672d0e4">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

