### PR TITLE
Extend support for deprecated "JLoader::register()" method. For PR 45878

### DIFF
--- a/migrations/53-54/new-deprecations.md
+++ b/migrations/53-54/new-deprecations.md
@@ -56,6 +56,12 @@ Example implementations using the new APIs:
  - [Editors Plugin](/docs/building-extensions/plugins/plugin-examples/editors-plugin/)
  - [Editors Buttons (XTD) Plugin](/docs/building-extensions/plugins/plugin-examples/editors-xtd-plugin/)
  - [Captcha Plugin](/docs/building-extensions/plugins/plugin-examples/captcha-plugin/)
+
+### Support for the deprecated `register` method of the `JLoader` class was extended from Joomla 6 to Joomla 7.
+
+[45878](https://github.com/joomla/joomla-cms/pull/45878): Support for the deprecated `JLoader::register()` method was extended from Joomla 6 to Joomla 7.
+The `JLoader::register()` method will be removed in Joomla 7 instead of Joomla 6.
+
 ### Deprecation of `$_db`, `getDbo()`, and `setDbo()`
 [45165](https://github.com/joomla/joomla-cms/pull/45165) – Replace table _db with DatabaseAwareTrait
 


### PR DESCRIPTION
### **User description**
For PR https://github.com/joomla/joomla-cms/pull/45878 .


___

### **PR Type**
Documentation


___

### **Description**
- Extended deprecation timeline for `JLoader::register()` method

- Updated migration documentation for Joomla 5.3-5.4


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["JLoader::register()"] --> B["Deprecated in Joomla 5"]
  B --> C["Originally scheduled for removal in Joomla 6"]
  C --> D["Extended to removal in Joomla 7"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>new-deprecations.md</strong><dd><code>Document JLoader::register() deprecation extension</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/53-54/new-deprecations.md

<ul><li>Added documentation for extended deprecation timeline<br> <li> Referenced PR 45878 for JLoader::register() method<br> <li> Updated removal schedule from Joomla 6 to Joomla 7</ul>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/494/files#diff-bbc8f111403603cb8a23812e5045473bd44f59ef022624fc8567e2a8b672d0e4">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

