### PR TITLE
Deprecate app input property

### DIFF
--- a/migrations/54-60/new-deprecations.md
+++ b/migrations/54-60/new-deprecations.md
@@ -11,3 +11,22 @@ New Deprecations
 
 All the new deprecations that should be aware of and what you should now be using instead.
 
+
+### Application input property is deprecated
+
+PR: [46000](https://github.com/joomla/joomla-cms/pull/46000)
+Files: 
+- `libraries/vendor/joomla/application/src/AbstractWebApplication.php`
+- `libraries/src/Application/WebApplication.php`
+Description:
+The `input` property is deprecated in the AbstractWebApplication class since Joomla 4.0, but it was not really obvious in the CMS classes because of class hierarchy. Access to the `input` property got now removed in the framework class but is still available in the CMS classes. It will trigger a deprecated warning when directly called.
+
+```php
+// Old code
+$app->input->get('foo');
+Factory::getApplication()->input->get('foo');
+
+// New:
+$app->getInput()->get('foo');
+Factory::getApplication()->getInput()->get('foo');
+```


### PR DESCRIPTION
### **User description**
https://github.com/joomla/joomla-cms/pull/46000


___

### **PR Type**
Documentation


___

### **Description**
- Document deprecation of application `input` property

- Add migration guide with code examples

- Reference PR #46000 for framework changes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old: app->input->get()"] -- "deprecated" --> B["New: app->getInput()->get()"]
  C["Framework removal"] -- "triggers" --> D["CMS deprecation warning"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>new-deprecations.md</strong><dd><code>Document application input property deprecation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/54-60/new-deprecations.md

<ul><li>Add new section documenting <code>input</code> property deprecation<br> <li> Include PR reference and affected files list<br> <li> Provide before/after code examples for migration<br> <li> Explain deprecation context and warning behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/508/files#diff-95c7f39a63008ca5fe94b72378c93f17faaf3f9168f672372e1fdcef5004c73c">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

