### PR TITLE
migrations/53-54 Removed 45685

### DIFF
--- a/migrations/53-54/new-features.md
+++ b/migrations/53-54/new-features.md
@@ -27,7 +27,6 @@ designed to prevent supply chain attacks when automatically updating Joomla core
 * [45143](https://github.com/joomla/joomla-cms/pull/45143) Add Automated Core Updates client functionality
 * [45517](https://github.com/joomla/joomla-cms/pull/45517) Add Automated Updates information as fieldset description
 * [45547](https://github.com/joomla/joomla-cms/pull/45547) Improve Automated Update UX for local sites
-* [45685](https://github.com/joomla/joomla-cms/pull/45685) Notify all super users of Automated Updates
 * [45669](https://github.com/joomla/joomla-cms/pull/45669) Improve Automated Update Quickicon language keys and icon
 * [45697](https://github.com/joomla/joomla-cms/pull/45697) Allow opt-out from automated updates during installation
 * [45721](https://github.com/joomla/joomla-cms/pull/45721) Autoupdate email groups


### PR DESCRIPTION
### **User description**
As [#45685](https://github.com/joomla/joomla-cms/pull/45685) - 'Notify all super users of Automated Updates' functionality is overwritten by [#45721](https://github.com/joomla/joomla-cms/pull/45721) - 'Autoupdate email groups'.


___

### **PR Type**
Documentation


___

### **Description**
- Remove duplicate automated update notification feature from migration docs

- Clean up feature list after functionality consolidation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Migration docs 53-54"] -- "remove duplicate" --> B["Cleaned feature list"]
  C["PR 45685 functionality"] -- "replaced by" --> D["PR 45721 email groups"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>new-features.md</strong><dd><code>Remove duplicate automated update notification entry</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/53-54/new-features.md

<ul><li>Removed reference to PR 45685 from automated updates feature list<br> <li> Cleaned up duplicate functionality documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/510/files#diff-82d235dce5d3f7ee19ec0e41cfe16de4e8cc4da567ec2a473b093adffa0efb96">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

