### PR TITLE
Update joomla-dialog.md

### DIFF
--- a/docs/general-concepts/javascript/js-library/joomla-dialog.md
+++ b/docs/general-concepts/javascript/js-library/joomla-dialog.md
@@ -21,7 +21,7 @@ Provides helper to bind page button/anchor to show the popup, for basic stuff, w
 - `popupType` (string) The popup type, supported: `inline`, `iframe`, `image`, `ajax`.
 - `src` (string) Source path for iframe, image, ajax.
 - `popupContent` (string|HTMLElement|HTMLTemplateElement) Content for inline type popup.
-- `cancelable` (boolean) Whether popup can be closed by `Esc` button.
+- `cancelable` (boolean) Whether popup can be closed by `Esc` button. (default = true)
 - `textClose` (string) An optional text for close button. Applied when no Buttons provided.
 - `textHeader` (string) An optional text for header.
 - `iconHeader` (string) An optional Class names for header icon.


### PR DESCRIPTION
### **User description**
The property `cancelable` has a default value. It is worth mentioning this in the documentation so I do not have to test what the default value is


___

### **PR Type**
Documentation


___

### **Description**
- Add default value documentation for `cancelable` property


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>joomla-dialog.md</strong><dd><code>Document cancelable property default value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/general-concepts/javascript/js-library/joomla-dialog.md

<ul><li>Added default value <code>(default = true)</code> to <code>cancelable</code> property <br>documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/525/files#diff-9aa158c3844230a21684cbcbd5d082fbd33bef1e379f46aa18331ca48e339810">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

