### PR TITLE
Note for onBeforeExecute event

### DIFF
--- a/migrations/54-60/new-features.md
+++ b/migrations/54-60/new-features.md
@@ -292,7 +292,7 @@ It is now possible to batch remove a tag. PR: https://github.com/joomla/joomla-c
 - **PR**: [#45426](https://github.com/joomla/joomla-cms/pull/45426) by **Fedik**  
 - **Usage**: Subscribe to `onBeforeExecute` to hook before app runs.  
 - **Impact**: Enables pre-routing plugins.
-- **Note**: The language available only onAfterInitialise event, and if you're trying to use language in the plugin constructor consider to move this logic in to the even callback.
+- **Note**: The language available only onAfterInitialise event, and if you're trying to use language in the plugin constructor consider to move this logic in to the event callback.
 
 ---
 

--- a/migrations/54-60/new-features.md
+++ b/migrations/54-60/new-features.md
@@ -292,6 +292,7 @@ It is now possible to batch remove a tag. PR: https://github.com/joomla/joomla-c
 - **PR**: [#45426](https://github.com/joomla/joomla-cms/pull/45426) by **Fedik**  
 - **Usage**: Subscribe to `onBeforeExecute` to hook before app runs.  
 - **Impact**: Enables pre-routing plugins.
+- **Note**: The language available only onAfterInitialise event, and if you're trying to use language in the plugin constructor consider to move this logic in to the even callback.
 
 ---
 

--- a/migrations/54-60/new-features.md
+++ b/migrations/54-60/new-features.md
@@ -292,7 +292,7 @@ It is now possible to batch remove a tag. PR: https://github.com/joomla/joomla-c
 - **PR**: [#45426](https://github.com/joomla/joomla-cms/pull/45426) by **Fedik**  
 - **Usage**: Subscribe to `onBeforeExecute` to hook before app runs.  
 - **Impact**: Enables pre-routing plugins.
-- **Note**: The language available only onAfterInitialise event, and if you're trying to use language in the plugin constructor consider to move this logic in to the event callback.
+- **Note**: The language is available only onAfterInitialise event. If you're trying to use language in the plugin constructor, consider to move this logic into the event callback.
 
 ---
 


### PR DESCRIPTION
### **User description**
PR for:
- https://github.com/joomla/joomla-cms/pull/45426
- https://github.com/joomla/joomla-cms/pull/46237


___

### **PR Type**
Documentation


___

### **Description**
- Added language availability note for `onBeforeExecute` event


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>new-features.md</strong><dd><code>Added language availability note for onBeforeExecute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

migrations/54-60/new-features.md

<ul><li>Added note about language availability timing for <code>onBeforeExecute</code> <br>event<br> <li> Clarified that language is only available after <code>onAfterInitialise</code> <br>event<br> <li> Recommended moving language logic from plugin constructor to event <br>callback</ul>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/536/files#diff-1759a8daad05cbac620d11e5edc6057eec7cbca0e149d12aaac323445446bb53">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

