### PR TITLE
Fix Required Version for Maria DB - Joomla6

### DIFF
--- a/docs/get-started/technical-requirements.md
+++ b/docs/get-started/technical-requirements.md
@@ -16,7 +16,7 @@ Joomla! version. The *Minimum* versions are guaranteed to work. Older versions m
 | PHP                | 8.4         | 8.3.0   | 8.3.0    |
 | **Databases**      |             |         |          |
 | MySQL              | 8.4         | 8.0.13  | 8.0.13   |
-| MariaDB            | 12.0        | 10.6    | 10.4     |
+| MariaDB            | 12.0        | 10.6    | 10.6     |
 | PostgreSQL         | 17.6        | 14.0    | 12.0     |
 | **Web Servers**    |             |         |          |
 | Apache             | 2.4         | 2.4     |          |


### PR DESCRIPTION
### **User description**
Previously it had the required column set to Maria DB 10.4 but the minimum set to 10.6. I updated the required column to reflect the minimum version of 10.6


___

### **PR Type**
Bug fix


___

### **Description**
- Updates MariaDB required version from 10.4 to 10.6

- Aligns required version with minimum version requirement


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>technical-requirements.md</strong><dd><code>Update MariaDB required version to 10.6</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/get-started/technical-requirements.md

<ul><li>Changed MariaDB required version column from 10.4 to 10.6<br> <li> Ensures consistency between minimum and required version <br>specifications</ul>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/538/files#diff-552d80425038f200ae721b924cd92b5f043c548342805a47aebb235c69344e46">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

