### PR TITLE
Fix Required Version for PostgreSQL

### DIFF
--- a/docs/get-started/technical-requirements.md
+++ b/docs/get-started/technical-requirements.md
@@ -17,7 +17,7 @@ Joomla! version. The *Minimum* versions are guaranteed to work. Older versions m
 | **Databases**      |             |         |          |
 | MySQL              | 8.4         | 8.0.13  | 8.0.13   |
 | MariaDB            | 12.0        | 10.6    | 10.4     |
-| PostgreSQL         | 17.6        | 14.0    | 12.0     |
+| PostgreSQL         | 17.6        | 14.0    | 14.0     |
 | **Web Servers**    |             |         |          |
 | Apache             | 2.4         | 2.4     |          |
 | Nginx              | 1.29        | 1.26    |          |


### PR DESCRIPTION
### **User description**
Previously the PostgreSQL version had a minimum versino of 14.0 listed but a required version of 12.0 listed. I updated it so that the required version matches the minimum version. Same as the mariadb fix I just submitted. I didn't notice it before I submitted that last PR.


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Corrected PostgreSQL required version from 12.0 to 14.0

- Aligned required version with minimum version specification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PostgreSQL Version Table"] -- "Update required version" --> B["12.0 → 14.0"]
  B -- "Match minimum version" --> C["Consistent specification"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>technical-requirements.md</strong><dd><code>Correct PostgreSQL required version specification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/get-started/technical-requirements.md

<ul><li>Updated PostgreSQL required version from 12.0 to 14.0<br> <li> Aligned required version with minimum version requirement<br> <li> Maintains consistency with other database version specifications</ul>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/539/files#diff-552d80425038f200ae721b924cd92b5f043c548342805a47aebb235c69344e46">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

