### PR TITLE
Fix incorrect PHP date format example in calendar field documentation

### DIFF
--- a/docs/general-concepts/forms-fields/standard-fields/calendar.md
+++ b/docs/general-concepts/forms-fields/standard-fields/calendar.md
@@ -19,7 +19,7 @@ the text box. Otherwise the default value, if any, is displayed.
 - **class** (optional) is a CSS class name for the HTML form field.
 - **format** (optional) is the date format to be used. This is in the format used by PHP to specify date string formats (see below). 
   - If no format argument is given, '%Y-%m-%d' is assumed (giving dates like '2017-05-15'). 
-  - If showtime is true then you will need to include some time fields, for example, '%Y-%m-%d %H:%i:%s'.
+  - If showtime is true then you will need to include some time fields, for example, '%Y-%m-%d %H:%M:%S'.
 - **filter** (optional) is time zone to be used. There are two main values: "server_utc" and "user_utc". The first one is server time zone and the later is user time zone as configured in global configuration and user information respectively. There is also a value of none which must be used if the server time zone is set to something other than UTC and showtime is false.
 - **translateformat** (optional) If set to true, the calendar will use the DATE_FORMAT_CALENDAR_DATE language key (if showtime is true) or DATE_FORMAT_CALENDAR_DATETIME (if showtime is false) to determine the format. The format attribute is ignored. If false, the format attribute is used but note that the format string must include time fields for the time to be recorded. Defaults to false.
 - **showtime** (optional) If set to true and translateformat is true, the language key DATE_FORMAT_CALENDAR_DATETIME is used, otherwise DATE_FORMAT_CALENDAR_DATE. Defaults to false.


### PR DESCRIPTION
### **User description**
This pull request corrects the date format example in the Calendar Field documentation page (#543 ).

The previous example used MySQL-style placeholders (%i and %s), which are invalid in PHP date formatting.

Using %i and %s would not render correctly when interpreted by PHP functions (e.g., strftime, date_format).

Correcting it to %M and %S ensures consistency with PHP’s date formatting standards and prevents confusion for developers referencing this documentation.

Details of the Change :
Before change :
```
%Y-%m-%d %H:%i:%s
``` 
After change : 
```
%Y-%m-%d %H:%M:%S
```


___

### **PR Type**
Documentation


___

### **Description**
- Corrects invalid PHP date format placeholders in calendar field documentation

- Changes MySQL-style %i and %s to valid PHP format %M and %S

- Ensures consistency with PHP date formatting standards


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MySQL Format<br/>%H:%i:%s"] -- "Corrected to" --> B["PHP Format<br/>%H:%M:%S"]
  B -- "Applied to" --> C["Calendar Field Doc"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>calendar.md</strong><dd><code>Correct PHP date format placeholders in example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/general-concepts/forms-fields/standard-fields/calendar.md

<ul><li>Updated date format example from '%Y-%m-%d %H:%i:%s' to '%Y-%m-%d <br>%H:%M:%S'<br> <li> Replaced invalid MySQL-style time placeholders (%i, %s) with valid PHP <br>equivalents (%M, %S)<br> <li> Maintains consistency with PHP date formatting standards in <br>documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/547/files#diff-3167bffa15c54d5e843b6b00bae60b1ca45ab3f6baea7f7ef84992dca6aa95d6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

