### PR TITLE
Update manifest.md

### DIFF
--- a/versioned_docs/version-6.0/building-extensions/install-update/installation/manifest.md
+++ b/versioned_docs/version-6.0/building-extensions/install-update/installation/manifest.md
@@ -73,7 +73,7 @@ In priority order the 'element' database field is set
 - from the "module=" or "plugin=" attribute in the `<files>`, or
 - from the `<name>` (after the text is cleaned).
 
-## Root Element
+## Root 
 
 The primary tag of the installation file is
 
@@ -97,19 +97,19 @@ This starting and closing tag is the same for all extensions. The following attr
 The following elements can be used to insert metadata. Although not strictly required, you should define at least the `<name>`, `<author>`, `<version>` and `<description>` tags, all of which are used on the default administrator Manage Extensions form.
 
 ```xml
-<name> – extension name (e.g. com_banners).
-<author> – author's name (e.g. Joomla! Project)
-<creationDate> – date of creation or release (e.g. April 2006)
-<copyright> – a copyright statement (e.g. (C) 2020 - 2030 Open Source Matters. All rights reserved.)
-<license> – a license statement (e.g. GNU General Public License version 3 or later; see LICENSE.txt)
-<authorEmail> – author's email address (e.g. admin@joomla.org)
-<authorUrl> – URL to the author's website (e.g. www.joomla.org)
-<version> – the version number of the extension (e.g. 1.6.0)
-<description> – the description of the component (may be shown as a tooltip on the admin Manage Extensions page)
-<element> – the internal name of the component. If omitted, name will be cleaned and used
+<name> – extension name (e.g. com_banners);
+<author> – author's name (e.g. Joomla! Project);
+<creationDate> – date of creation or release (e.g., April 2006);
+<copyright> – a copyright statement (e.g., (C) 2020 - 2030 Open Source Matters. All rights reserved.);
+<license> – a license statement (e.g., GNU General Public License version 3 or later; see LICENSE.txt);
+<authorEmail> – author's email address (e.g., admin@joomla.org);
+<authorUrl> – URL to the author's website (e.g., www.joomla.org);
+<version> – the version number of the extension (e.g., 1.6.0);
+<description> – the description of the component (may be shown as a tooltip on the admin Manage Extensions page);
+<element> – the internal name of the component. If omitted, the file name (without extension) will be cleaned and used.
 ```
 
-The `<name>` and `<description>` fields are translatable. If you use language strings for these elements then they should be defined in your language .sys.ini file AND your .ini file.
+The `<name>` and `<description>` fields are translatable. If you use language strings for these elements, then they should be defined in your language .sys.ini file AND your .ini file.
 
 ## Frontend Files
 


### PR DESCRIPTION
### **User description**
<element> if omitted is taken from the file name, not from the <name> tag, right?


___

### **PR Type**
Documentation


___

### **Description**
- Clarify `<element>` field behavior when omitted from manifest

- Add semicolons for consistency in XML element descriptions

- Improve grammar and punctuation in documentation

- Simplify section heading from "Root Element" to "Root"


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["manifest.md documentation"] -- "clarify element behavior" --> B["element uses filename if omitted"]
  A -- "improve formatting" --> C["add semicolons to descriptions"]
  A -- "enhance grammar" --> D["fix punctuation and wording"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.md</strong><dd><code>Clarify element field and improve documentation formatting</code></dd></summary>
<hr>

versioned_docs/version-6.0/building-extensions/install-update/installation/manifest.md

<ul><li>Changed section heading from "Root Element" to "Root"<br> <li> Updated <code><element></code> description to clarify it uses file name (without extension) <br>when omitted, not the <code><name></code> tag<br> <li> Added semicolons to all XML element descriptions for consistency<br> <li> Improved grammar by adding commas after "e.g." and before "then" in <br>the translatable fields note</ul>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/552/files#diff-333d83f9af8aeb47d76fb601c631ebe435b4e6fec3edf9d9567d5b3425485eea">+14/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

