### PR TITLE
Add layout option for list field documentation

### DIFF
--- a/docs/general-concepts/forms-fields/standard-fields/list.md
+++ b/docs/general-concepts/forms-fields/standard-fields/list.md
@@ -11,6 +11,7 @@ The **list** form field type provides  a drop down list or a list box of custom-
 - **description** (optional) (translatable) is the [field description](../standard-form-field-attributes.md#description).
 - **class** (optional) is a CSS class name for the HTML form field. If omitted this will default to 'inputbox'.
 - **multiple** (optional) if set to true allows multiple items to be selected at the same time. Set to false to allow single selection.
+- **layout** (optional) use define custom layout or use `joomla.form.field.list-fancy-select` as layout to get a more dynamic layout for your lists.
 - **required** (optional) if set to true, the first field option should be empty, see last example.
 - **useglobal** (optional) if set to true, it will show the value that is set in the global configuration if found in the database.
 


### PR DESCRIPTION
### **User description**
Added missing layout parameter – specifically mentioned the option for fancy select.


___

### **PR Type**
Documentation


___

### **Description**
- Added `layout` parameter documentation for list field

- Documented fancy select layout option for dynamic lists


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["List Field Documentation"] -- "Add layout parameter" --> B["layout optional parameter"]
  B -- "supports" --> C["joomla.form.field.list-fancy-select"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>list.md</strong><dd><code>Add layout parameter documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/general-concepts/forms-fields/standard-fields/list.md

<ul><li>Added documentation for the <code>layout</code> optional parameter<br> <li> Explained usage of <code>joomla.form.field.list-fancy-select</code> for dynamic <br>list layouts<br> <li> Clarified that layout can be customized or use predefined fancy select <br>option</ul>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/563/files#diff-fbf022c3fe339f6ec2f1945377b0281a5e20d396f96023f93d11fc596cb5c478">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

