### PR TITLE
Fix template-details.xml

### DIFF
--- a/docs/building-extensions/templates/template-details-file.md
+++ b/docs/building-extensions/templates/template-details-file.md
@@ -14,7 +14,7 @@ The sections are defined as:
 	<authorEmail><!-- Author's email of the template go here --></authorEmail>
 	<copyright><!-- Copyright of the template go here --></copyright>
 	<description><!-- Description of the template go here --></description>
-  <namespace><!-- Description of the template go here, usually CompanyNamespace\Templates\Templatename --></namespace>
+	<namespace><!-- Description of the template go here, usually CompanyNamespace\Templates\Templatename --></namespace>
 	<inheritable>1</inheritable>
 	<files><!-- Files/Folders for the template folder entries go here --></files>
 	<media destination="templates/site/<!-- Name of the template go here -->" folder="media"><!-- Folders for the static assets entries go here --></media>


### PR DESCRIPTION
### **User description**
fix a typo and hard coded temolate name


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fixed XML syntax error: removed extra `>` in `<copyright>` tag

- Replaced hardcoded template name with placeholder in `destination` attribute

- Updated documentation to reflect correct template structure


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["template-details.xml<br/>documentation"] -->|"Remove extra >"| B["Fix copyright tag<br/>syntax error"]
  A -->|"Replace hardcoded<br/>cassiopeia name"| C["Add dynamic<br/>destination placeholder"]
  B --> D["Corrected XML<br/>structure"]
  C --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>template-details-file.md</strong><dd><code>Fix XML syntax and template name placeholder</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/building-extensions/templates/template-details-file.md

<ul><li>Fixed malformed <code><copyright></code> tag by removing extra <code>></code> character<br> <li> Replaced hardcoded <code>cassiopeia</code> template name with placeholder comment <br><code><!-- Name of the template go here --></code><br> <li> Improved documentation to show correct XML structure for template <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/570/files#diff-a2ab429c6963ae8de5a6c25a194a68a0621ca24dd1b6caf35bfb07437173b04e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

