### PR TITLE
Clarify update script execution during installation

### DIFF
--- a/versioned_docs/version-6.0/building-extensions/install-update/installation/manifest.md
+++ b/versioned_docs/version-6.0/building-extensions/install-update/installation/manifest.md
@@ -343,6 +343,11 @@ If you install one version of the extension then skip some versions before insta
 The currently installed version is maintained in the `#__schemas` table.
 You can find a worked example in [Developing an MVC Component/Using the database](https://docs.joomla.org/J3.x:Developing_an_MVC_Component/Using_the_database).
 
+:::warning[Important]
+   When the corresponding component is initially installed, the update scripts are not executed. 
+   The `example.install.sql` must contain the current status of all database changes and thus describe the current status.
+:::
+
 :::note[TODO]
   Update the above link when the MVC Component Tutorial is included in the manual.
 :::


### PR DESCRIPTION
### **User description**
Added warning about update scripts not executing during initial installation.


___

### **PR Type**
Documentation


___

### **Description**
- Added warning clarifying update scripts don't execute during initial installation

- Emphasized that install.sql must contain current database schema status


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Installation Documentation"] -- "adds clarification" --> B["Update Scripts Warning"]
  B -- "explains" --> C["Install SQL Requirements"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>manifest.md</strong><dd><code>Add installation update script execution warning</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

versioned_docs/version-6.0/building-extensions/install-update/installation/manifest.md

<ul><li>Added warning box clarifying that update scripts don't execute during <br>initial component installation<br> <li> Documented requirement that example.install.sql must contain current <br>database schema status<br> <li> Placed warning before existing TODO note for better visibility</ul>


</details>


  </td>
  <td><a href="https://github.com/joomla/Manual/pull/571/files#diff-333d83f9af8aeb47d76fb601c631ebe435b4e6fec3edf9d9567d5b3425485eea">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

