### PR TITLE
Adds missing description of second client side form validation function parameter

### DIFF
--- a/docs/general-concepts/forms/client-side-validation.md
+++ b/docs/general-concepts/forms/client-side-validation.md
@@ -99,12 +99,12 @@ will reject the data if there is a letter "x" within the field.
 
 You can write your own javascript validation function as described below. The [com_exampleform](../../building-extensions/components/component-examples/example-form-component.md) example component (which can be downloaded from [here](https://github.com/joomla/manual-examples/tree/main/component-exampleform)) provides a working example of client-side validation.
 
-1. Step 1 Write the js function. (Although a regex is used below, you're obviously not limited to this). The value of the field is passed in the `value` parameter, and you should return `true` if the value is valid, or `false` if it isn't.
+1. Step 1 Write the js function. (Although a regex is used below, you're obviously not limited to this). The value of the field is passed in the `value` parameter. The HTML element corresponding to the field is passed in the `element` parameter. The function should return `true` if the value is valid, or `false` if it isn't. 
 
 ```js title="no-uppercase.js"
 window.onload = (event) => {
     document.formvalidator.setHandler('noUppercase',
-        function (value) {
+        function (value, element) {
             // look for any uppercase characters 
             regex=/[A-Z]/g;
             // we should return false if any uppercase characters are found


### PR DESCRIPTION
A custom client side form validation routine receives two parameters. Only the first one, the field `value` was documented. This PR documents the HTML `element` which is passed as the second parameter to the validation function.