### PR TITLE
tidy up of technical requirements

### DIFF
--- a/docs/get-started/technical-requirements.md
+++ b/docs/get-started/technical-requirements.md
@@ -5,9 +5,10 @@ Technical Requirements
 ======================
 
 ## Requirements for Supported Software
-- You should use at least the version listed in the **Recommended"**.
+- You should use at least the version listed in the **Recommended** column.
 - The minimum supported version is listed in the **Supported** column.
-- The version in the **Minimum** column is the absolute minimum, but it is not supported — if you choose to use it, you are responsible for resolving any issues that may arise.
+- The version in the **Minimum** column is the absolute minimum, 
+but if it is below the **Supported** version then if you choose to use it, you are responsible for resolving any issues that may arise.
 
 ### Requirements for Joomla! 6.x
 
@@ -25,31 +26,9 @@ Technical Requirements
 
 **Required PHP Modules:** json, simplexml, dom, zlib, gd, mysqlnd or pdo_mysql or pdo_pgsql  
 **Recommended PHP Modules:** mbstring  
+**Recommended PHP Memory Limit:** at least 256MB  
 **Optional Apache Modules:** _mod_rewrite_ extension to use SEO URLs  
 **Optional Microsoft IIS Modules:** [URL Rewrite Module](https://www.iis.net/downloads/microsoft/url-rewrite) to use SEO URLs
-
-### Requirements for Joomla! 5.x
-
-| Software           | Recommended     | Minimum     |
-|--------------------|-----------------|-------------|
-| PHP                | 8.3             | 8.1.0       |
-| **Databases**      |                 |             |
-| MySQL              | 8.1             | 8.0.13      |
-| MariaDB            | 11.1.0          | 10.4.0      |
-| PostgreSQL         | 16.0            | 12.0        |
-| **Web Servers**    |                 |             |
-| Apache             | 2.4             | 2.4         |
-| Nginx              | 1.25            | 1.21        |
-| Microsoft IIS      | 10              | 10          |
-
-**Required PHP Modules:** json, simplexml, dom, zlib, gd, mysqlnd or pdo_mysql or pdo_pgsql  
-**Optional Apache Modules:** _mod_rewrite_ extension to use SEO URLs  
-**Optional Microsoft IIS Modules:** [URL Rewrite Module](https://learn.iis.net/page.aspx/460/using-url-rewrite-module/) to use SEO URLs
-
-### Requirements for older Versions
-
-If you need the requirements for older Joomla versions please use the Current Releases 
-version switcher in the top left corner to select the [4.4 (Security)](/versioned_docs/version-4.4/get-started/technical-requirements.md) version.
 
 ## Additional Information
 
@@ -61,21 +40,20 @@ version switcher in the top left corner to select the [4.4 (Security)](/versione
 - [Nginx](https://nginx.org) is an HTTP web server, reverse proxy, content cache and load balancer.
 - [Microsoft IIS](https://www.iis.net) (Internet Information Services) for Windows® Server is a flexible, secure and manageable Web server for hosting anything on the Web.
 
-### Glossar
+### Glossary
 
 #### Recommended
 
 This column describes which version the Joomla! Project recommends to use for the selected Joomla version.
 
-#### Minimum
+#### Supported
 
 This column describes which version the Joomla! Project has set as the minimum supported version.
 This means any bug found in this version or higher will be considered for fixing. This version might
-not be enforced. The minimum version usually reflects the latest version of the software package
-supported by the vendor.
+not be enforced. 
 
-#### Required
+#### Minimum
 
-This column describes the enforced version by the CMS or the framework in use. That means you may use
-a lower version than the minimum version, but not lower than the required version. For versions below
-the minimum version, you might not receive support from the Joomla maintainers.
+This column describes the minimum version enforced by the CMS or the framework in use. That means you may sometimes use
+a lower version than the supported version, but not lower than the minimum version. For versions below
+the supported version, you might not receive support from the Joomla maintainers.

--- a/versioned_docs/version-5.4/get-started/technical-requirements.md
+++ b/versioned_docs/version-5.4/get-started/technical-requirements.md
@@ -23,29 +23,9 @@ In the following tables the *Recommended* versions of supporting software are kn
 | Microsoft IIS      | 10              | 10          |
 
 **Required PHP Modules:** json, simplexml, dom, zlib, gd, mysqlnd or pdo_mysql or pdo_pgsql  
+**Recommended PHP Memory Limit:** at least 256MB  
 **Optional Apache Modules:** _mod_rewrite_ extension to use SEO URLs  
 **Optional Microsoft IIS Modules:** [URL Rewrite Module](https://learn.iis.net/page.aspx/460/using-url-rewrite-module/) to use SEO URLs
-
-### Requirements for Joomla! 4.x
-
-| Software           | Recommended     | Minimum     |
-|--------------------|-----------------|-------------|
-| PHP                | 8.2             | 7.2.5       |
-| **Databases**      |                 |             |
-| MySQL              | 8.0             | 5.6         |
-| PostgreSQL         | 11.0            | 11.0        |
-| **Web Servers**    |                 |             |
-| Apache             | 2.4             | 2.4         |
-| Nginx              | 1.18            | 1.10        |
-| Microsoft IIS      | 10              | 8           |
-
-**Required PHP Modules:** json, simplexml, dom, zlib, gd, mysqlnd or pdo_mysql or pdo_pgsql  
-**Optional Apache Modules:** _mod_rewrite_ extension to use SEO URLs  
-**Optional Microsoft IIS Modules:** [URL Rewrite Module](https://learn.iis.net/page.aspx/460/using-url-rewrite-module/) to use SEO URLs
-
-### Requirements for older Versions
-
-If you need the requirements for older Joomla versions please use the Current Releases version switcher in the top right corner to select the [4.4 (Security)](/versioned_docs/version-4.4/get-started/technical-requirements.md) version.
 
 ## Additional Information
 

--- a/versioned_docs/version-6.1/get-started/technical-requirements.md
+++ b/versioned_docs/version-6.1/get-started/technical-requirements.md
@@ -5,9 +5,10 @@ Technical Requirements
 ======================
 
 ## Requirements for Supported Software
-- You should use at least the version listed in the **Recommended"**.
+- You should use at least the version listed in the **Recommended** column.
 - The minimum supported version is listed in the **Supported** column.
-- The version in the **Minimum** column is the absolute minimum, but it is not supported — if you choose to use it, you are responsible for resolving any issues that may arise.
+- The version in the **Minimum** column is the absolute minimum, 
+but if it is below the **Supported** version then if you choose to use it, you are responsible for resolving any issues that may arise.
 
 ### Requirements for Joomla! 6.x
 
@@ -25,31 +26,9 @@ Technical Requirements
 
 **Required PHP Modules:** json, simplexml, dom, zlib, gd, mysqlnd or pdo_mysql or pdo_pgsql  
 **Recommended PHP Modules:** mbstring  
+**Recommended PHP Memory Limit:** at least 256MB  
 **Optional Apache Modules:** _mod_rewrite_ extension to use SEO URLs  
 **Optional Microsoft IIS Modules:** [URL Rewrite Module](https://www.iis.net/downloads/microsoft/url-rewrite) to use SEO URLs
-
-### Requirements for Joomla! 5.x
-
-| Software           | Recommended     | Minimum     |
-|--------------------|-----------------|-------------|
-| PHP                | 8.3             | 8.1.0       |
-| **Databases**      |                 |             |
-| MySQL              | 8.1             | 8.0.13      |
-| MariaDB            | 11.1.0          | 10.4.0      |
-| PostgreSQL         | 16.0            | 12.0        |
-| **Web Servers**    |                 |             |
-| Apache             | 2.4             | 2.4         |
-| Nginx              | 1.25            | 1.21        |
-| Microsoft IIS      | 10              | 10          |
-
-**Required PHP Modules:** json, simplexml, dom, zlib, gd, mysqlnd or pdo_mysql or pdo_pgsql  
-**Optional Apache Modules:** _mod_rewrite_ extension to use SEO URLs  
-**Optional Microsoft IIS Modules:** [URL Rewrite Module](https://learn.iis.net/page.aspx/460/using-url-rewrite-module/) to use SEO URLs
-
-### Requirements for older Versions
-
-If you need the requirements for older Joomla versions please use the Current Releases 
-version switcher in the top left corner to select the [4.4 (Security)](/versioned_docs/version-4.4/get-started/technical-requirements.md) version.
 
 ## Additional Information
 
@@ -61,21 +40,20 @@ version switcher in the top left corner to select the [4.4 (Security)](/versione
 - [Nginx](https://nginx.org) is an HTTP web server, reverse proxy, content cache and load balancer.
 - [Microsoft IIS](https://www.iis.net) (Internet Information Services) for Windows® Server is a flexible, secure and manageable Web server for hosting anything on the Web.
 
-### Glossar
+### Glossary
 
 #### Recommended
 
 This column describes which version the Joomla! Project recommends to use for the selected Joomla version.
 
-#### Minimum
+#### Supported
 
 This column describes which version the Joomla! Project has set as the minimum supported version.
 This means any bug found in this version or higher will be considered for fixing. This version might
-not be enforced. The minimum version usually reflects the latest version of the software package
-supported by the vendor.
+not be enforced. 
 
-#### Required
+#### Minimum
 
-This column describes the enforced version by the CMS or the framework in use. That means you may use
-a lower version than the minimum version, but not lower than the required version. For versions below
-the minimum version, you might not receive support from the Joomla maintainers.
+This column describes the minimum version enforced by the CMS or the framework in use. That means you may sometimes use
+a lower version than the supported version, but not lower than the minimum version. For versions below
+the supported version, you might not receive support from the Joomla maintainers.


### PR DESCRIPTION
I've removed the technical requirements of Joomla versions which didn't relate to the selected documentation version. 

The exception is for 4.4, which still contains information pertinent to earlier versions.

Also a fair bit of tidy-up done, and the change suggested in #588 included.

