### PR TITLE
Improve ICON description with link to guide.joomla.org icon list

### DIFF
--- a/docs/general-concepts/icons.md
+++ b/docs/general-concepts/icons.md
@@ -11,7 +11,7 @@ which are implemented as [CSS pseudo-elements](https://docs.fontawesome.com/web/
 
 Joomla implemented the free standard icons, brand icons and supports a subset "icon-..." to be compatible with J!3x and following versions
 
-The source list of available icons can be found in joomla file `media/templates/administrator/atum/css/vendor/fontawesome-free.css`. A visible representation of all icons with additional information see our [guide.joomla.org](https://guide.joomla.org/user-manual/templates/standard-icons?highlight=WyJpY29ucyJd)
+The source list of available icons can be found in joomla file `media/templates/administrator/atum/css/vendor/fontawesome-free.css`. A visible representation of all icons with additional information see our [guide.joomla.org](https://guide.joomla.org/user-manual/templates/standard-icons)
 
 ## Fontawesome icons
 Fontawesome icons can be used for HTML in following forms:

--- a/docs/general-concepts/icons.md
+++ b/docs/general-concepts/icons.md
@@ -38,7 +38,7 @@ The icon name part begins with ```fa-``` and the name. Example:
 
 ### Brand icons
 
-The prefix part is ```fab``` which is short for ```fa-brand``` which can be used instead
+The prefix part is ```fab``` which is short for ```fa-brands``` which can be used instead
 
 Example: 
 ```php

--- a/docs/general-concepts/icons.md
+++ b/docs/general-concepts/icons.md
@@ -11,12 +11,12 @@ which are implemented as [CSS pseudo-elements](https://docs.fontawesome.com/web/
 
 Joomla implemented the free standard icons, brand icons and supports a subset "icon-..." to be compatible with J!3x and following versions
 
-The source list of available icons can be found in joomla file ```media/templates/administrator/atum/css/vendor/fontawesome-free.css```. A visible representation of all icons with additional information see our [guide.joomla.org](https://guide.joomla.org/user-manual/templates/standard-icons?highlight=WyJpY29ucyJd)
+The source list of available icons can be found in joomla file `media/templates/administrator/atum/css/vendor/fontawesome-free.css`. A visible representation of all icons with additional information see our [guide.joomla.org](https://guide.joomla.org/user-manual/templates/standard-icons?highlight=WyJpY29ucyJd)
 
 ## Fontawesome icons
 Fontawesome icons can be used for HTML in following forms:
 
-```php
+```html
 <i style="font-size: 2rem;" class="fa fa-!name!"></i>
 <span class="fa fa-!name! "></span>
 ```
@@ -31,7 +31,7 @@ Add attribute ```aria-hidden="true"``` for hiding the icon from screen readers a
 The Prefix part is ```fa``` which is short for ```fas``` which is short for ```fa-solid``` which can be used instead.
 
 The icon name part begins with ```fa-``` and the name. Example: 
-```php
+```html
 <i class="fa fa-envelope"></i>
 <i class="fa-solid fa-save" aria-hidden="true"></i> <?php echo Text::_('JSAVE') ?> 
 ```
@@ -41,7 +41,7 @@ The icon name part begins with ```fa-``` and the name. Example:
 The prefix part is ```fab``` which is short for ```fa-brands``` which can be used instead
 
 Example: 
-```php
+```html
 <i class="fab fa-joomla"></i>
 <i class="fa-brands fa-facebook" aria-hidden="true"></i> <?php echo 'Facebook' ?> 
 ```
@@ -58,7 +58,7 @@ Form: ```<i class="icon-name"></i>```. The name has to be exchanged for icon nam
 Add attribute aria-hidden="true" for hiding the icon from screen readers and improves accessibility. 
 
 Example: 
-```php
+```html
 <i class="icon-joomla" style="font-size: 48px;" ></i>
 <i class="icon-joomla"  aria-hidden="true" style="font-size: 48px;" ></i>
 ```
@@ -68,13 +68,13 @@ Example:
 For example in HtmlView.php of a component the ToolBarHelper:: functions accept a icon name from this icon set.
 
 Example: 
-```php
+```html
 ToolBarHelper::title(Text::_('COM_EXAMPLE_TITLE'), 'envelope');
 ```
 
 :::tip
 Instead of using an 'icon' name of the icon class (see above) a fontawesome icon may be used instead in following form. It is helpful when the required symbol is not available — or looks better.
-```php
+```html
 ToolBarHelper::title(Text::_('COM_EXAMPLE_TITLE'), 'none fa fa-camera-retro');
 ```
 With 'none' given internally a 'icon-none' will be written into the HTML class and ' fa fa-camera-retro' will follow. 

--- a/docs/general-concepts/icons.md
+++ b/docs/general-concepts/icons.md
@@ -5,38 +5,86 @@ title: Icons
 Icons
 =====
 
-Joomla uses free [FontAwesome](https://fontawesome.com/search) icons,
+## Overview
+Joomla uses the free [FontAwesome](https://fontawesome.com/search) icons,
 which are implemented as [CSS pseudo-elements](https://docs.fontawesome.com/web/add-icons/pseudo-elements)
 
-The list of available icons can be found in media/templates/administrator/atum/css/vendor/fontawesome-free.css
+Joomla implemented the free standard icons, brand icons and supports a subset "icon-..." to be compatible with J!3x and following versions
 
-The subset of FontAwesome icons used internally within Joomla is designated with the prefix "icon-" (e.g., "icon-calendar", "icon-file", etc.)
-This is a remnant of the old coding style of FontAwesome; its latest versions use the "fa-" prefix, but Joomla is keeping the old prefix for backward compatibility.
+The source list of available icons can be found in joomla file ```media/templates/administrator/atum/css/vendor/fontawesome-free.css```. A visible representation of all icons with additional information see our [guide.joomla.org](https://guide.joomla.org/user-manual/templates/standard-icons?highlight=WyJpY29ucyJd)
 
-To display such an icon, you can use:
+## Fontawesome icons
+Fontawesome icons can be used for HTML in following forms:
 
 ```php
-    <span class="icon-cancel" aria-hidden="true"></span> <?php echo Text::_('JCANCEL') ?> 
+<i style="font-size: 2rem;" class="fa fa-!name!"></i>
+<span class="fa fa-!name! "></span>
 ```
 
-The attribute aria-hidden="true" hides the icon from screen readers and improves accessibility. 
+The actual icon name fa-!name! class is accompanied by a prefix class like "fa ..". More below or see [FontAwesome 'classic' styles](https://docs.fontawesome.com/web/dig-deeper/styles)  
+The \<span\> element can also do the job but the preferred way is to use classes inside the \<i\> element.
+
+Add attribute ```aria-hidden="true"``` for hiding the icon from screen readers and improves accessibility. Use attribute ```style="font-size: 2rem;"``` or ```style="font-size: 48px;"``` for the size of the icon font.
+
+### Standard icons
+
+The Prefix part is ```fa``` which is short for ```fas``` which is short for ```fa-solid``` which can be used instead.
+
+The icon name part begins with ```fa-``` and the name. Example: 
+```php
+<i class="fa fa-envelope"></i>
+<i class="fa-solid fa-save" aria-hidden="true"></i> <?php echo Text::_('JSAVE') ?> 
+```
+
+### Brand icons
+
+The prefix part is ```fab``` which is short for ```fa-brand``` which can be used instead
+
+Example: 
+```php
+<i class="fab fa-joomla"></i>
+<i class="fa-brands fa-facebook" aria-hidden="true"></i> <?php echo 'Facebook' ?> 
+```
+
+## Icomoon replacement form / 'icon' parameter in code function calls
+
+For this set of icons icon names from J3! (icomoon) were replaced (partly) by fontawesome icons. The icon itself is one of the fontawesome icons but the name may differ. Also this is a smaller subset with less icons. It is kept for compatibility with J!3 icomoon replacements. In joomla code there are functions which accept the icon name as parameter.
+
+### Direct Html use
+
+The class gets prefix "icon-" (e.g., "icon-calendar", "icon-file", etc.)
+
+Form: ```<i class="icon-name"></i>```. The name has to be exchanged for icon name. 
+Add attribute aria-hidden="true" for hiding the icon from screen readers and improves accessibility. 
+
+Example: 
+```php
+<i class="icon-joomla" style="font-size: 48px;" ></i>
+<i class="icon-joomla"  aria-hidden="true" style="font-size: 48px;" ></i>
+```
+
+### Parameter in J! functions
+
+For example in HtmlView.php of a component the ToolBarHelper:: functions accept a icon name from this icon set.
+
+Example: 
+```php
+ToolBarHelper::title(Text::_('COM_EXAMPLE_TITLE'), 'envelope');
+```
+
+:::tip
+Instead of using an 'icon' name of the icon class (see above) a fontawesome icon may be used instead in following form. It is helpful when the required symbol is not available — or looks better.
+```php
+ToolBarHelper::title(Text::_('COM_EXAMPLE_TITLE'), 'none fa fa-camera-retro');
+```
+With 'none' given internally a 'icon-none' will be written into the HTML class and ' fa fa-camera-retro' will follow. 
+Attention: This could affect subsequent button icons whose CSS formatting is then redefined.
+:::
+
+## Using other icon sets
 
 In case you want to display other icons not included in the Joomla pack, you have several options, one of which is to use additional FontAwesome icons.
 This can be achieved in different ways depending on your needs:
 1. Using FontAwesome Kit - this is the easiest approach, but you should have an account on their site.
 2. Using self-hosted webfonts and additional CSS files from FontAwesome.
 3. Using self-hosted SVG and JS files - for a few icons, this way you will have some speed optimization.
-
-According to [How To Add Icons](https://docs.fontawesome.com/web/add-icons/how-to), the CSS classes are prefixed "fa-" as "fa-solid" or "fa-brands".
-The preferred way is to use classes inside the `<i>` element:
-
-```html
-    <i class="fa-solid fa-calendar" aria-hidden="true"></i>
-```
-
-But the span element can also do the job:
-
-```php
-    <span class="fa-solid fa-bomb" aria-hidden="true"></span> <?php echo Text::_('JSAVE') ?> 
-    <span class="fa-brands fa-facebook" aria-hidden="true"></span> <?php echo 'Facebook' ?> 
-```

--- a/docs/general-concepts/icons.md
+++ b/docs/general-concepts/icons.md
@@ -2,7 +2,7 @@
 title: Icons
 ---
 
-Icons
+Standard Joomla! Icons 
 =====
 
 ## Overview

--- a/docs/general-concepts/icons.md
+++ b/docs/general-concepts/icons.md
@@ -54,7 +54,7 @@ For this set of icons icon names from J3! (icomoon) were replaced (partly) by fo
 
 The class gets prefix "icon-" (e.g., "icon-calendar", "icon-file", etc.)
 
-Form: ```<i class="icon-name"></i>```. The name has to be exchanged for icon name. 
+Form: ```<i class="icon-name"></i>```. The "name" part has to be replaced by the icon name. 
 Add attribute aria-hidden="true" for hiding the icon from screen readers and improves accessibility. 
 
 Example: 

--- a/docs/general-concepts/icons.md
+++ b/docs/general-concepts/icons.md
@@ -41,7 +41,7 @@ The icon name part begins with ```fa-``` and the name. Example:
 The prefix part is ```fab``` which is short for ```fa-brands``` which can be used instead
 
 Example: 
-```html
+```php
 <i class="fab fa-joomla"></i>
 <i class="fa-brands fa-facebook" aria-hidden="true"></i> <?php echo 'Facebook' ?> 
 ```

--- a/docs/general-concepts/icons.md
+++ b/docs/general-concepts/icons.md
@@ -11,7 +11,7 @@ which are implemented as [CSS pseudo-elements](https://docs.fontawesome.com/web/
 
 Joomla implemented the free standard icons, brand icons and supports a subset "icon-..." to be compatible with J!3x and following versions
 
-The source list of available icons can be found in joomla file `media/templates/administrator/atum/css/vendor/fontawesome-free.css`. A visible representation of all icons with additional information see our [guide.joomla.org](https://guide.joomla.org/user-manual/templates/standard-icons)
+The source list of available icons can be found in joomla file `media/templates/administrator/atum/css/vendor/fontawesome-free.css`. For a visible representation of all icons with additional information see our [guide.joomla.org](https://guide.joomla.org/user-manual/templates/standard-icons)
 
 ## Fontawesome icons
 Fontawesome icons can be used for HTML in following forms:

--- a/docs/general-concepts/icons.md
+++ b/docs/general-concepts/icons.md
@@ -48,7 +48,7 @@ Example:
 
 ## Icomoon replacement form / 'icon' parameter in code function calls
 
-For this set of icons icon names from J3! (icomoon) were replaced (partly) by fontawesome icons. The icon itself is one of the fontawesome icons but the name may differ. Also this is a smaller subset with fewer icons. It is kept for compatibility with J!3 icomoon replacements. In joomla code there are functions which accept the icon name as parameter.
+For this set of icons, icon names from J3! (icomoon) were replaced (partly) by fontawesome icons. The icon itself is one of the fontawesome icons but the name may differ. Also this is a smaller subset with fewer icons. It is kept for compatibility with J!3 icomoon replacements. In joomla code there are functions which accept the icon name as parameter.
 
 ### Direct Html use
 

--- a/docs/general-concepts/icons.md
+++ b/docs/general-concepts/icons.md
@@ -48,7 +48,7 @@ Example:
 
 ## Icomoon replacement form / 'icon' parameter in code function calls
 
-For this set of icons icon names from J3! (icomoon) were replaced (partly) by fontawesome icons. The icon itself is one of the fontawesome icons but the name may differ. Also this is a smaller subset with less icons. It is kept for compatibility with J!3 icomoon replacements. In joomla code there are functions which accept the icon name as parameter.
+For this set of icons icon names from J3! (icomoon) were replaced (partly) by fontawesome icons. The icon itself is one of the fontawesome icons but the name may differ. Also this is a smaller subset with fewer icons. It is kept for compatibility with J!3 icomoon replacements. In joomla code there are functions which accept the icon name as parameter.
 
 ### Direct Html use
 

--- a/docs/general-concepts/icons.md
+++ b/docs/general-concepts/icons.md
@@ -31,7 +31,7 @@ Add attribute ```aria-hidden="true"``` for hiding the icon from screen readers a
 The Prefix part is ```fa``` which is short for ```fas``` which is short for ```fa-solid``` which can be used instead.
 
 The icon name part begins with ```fa-``` and the name. Example: 
-```html
+```php
 <i class="fa fa-envelope"></i>
 <i class="fa-solid fa-save" aria-hidden="true"></i> <?php echo Text::_('JSAVE') ?> 
 ```

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -301,6 +301,7 @@ const config = {
       },
     }),
   plugins: [
+/*
     [
       require.resolve("@cmfcmf/docusaurus-search-local"),
       {
@@ -308,6 +309,7 @@ const config = {
         language: "en",
       },
     ],
+*/
     [
       'content-docs',
       /** @type {import('@docusaurus/plugin-content-docs').Options} */

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -301,7 +301,6 @@ const config = {
       },
     }),
   plugins: [
-/*
     [
       require.resolve("@cmfcmf/docusaurus-search-local"),
       {
@@ -309,7 +308,6 @@ const config = {
         language: "en",
       },
     ],
-*/
     [
       'content-docs',
       /** @type {import('@docusaurus/plugin-content-docs').Options} */

--- a/versioned_docs/version-4.4/general-concepts/icons.md
+++ b/versioned_docs/version-4.4/general-concepts/icons.md
@@ -2,41 +2,89 @@
 title: Icons
 ---
 
-Icons
+Standard Joomla! Icons 
 =====
 
-Joomla uses free [FontAwesome](https://fontawesome.com/search) icons,
+## Overview
+Joomla uses the free [FontAwesome](https://fontawesome.com/search) icons,
 which are implemented as [CSS pseudo-elements](https://docs.fontawesome.com/web/add-icons/pseudo-elements)
 
-The list of available icons can be found in media/templates/administrator/atum/css/vendor/fontawesome-free.css
+Joomla implemented the free standard icons, brand icons and supports a subset "icon-..." to be compatible with J!3x and following versions
 
-The subset of FontAwesome icons used internally within Joomla is designated with the prefix "icon-" (e.g., "icon-calendar", "icon-file", etc.)
-This is a remnant of the old coding style of FontAwesome; its latest versions use the "fa-" prefix, but Joomla is keeping the old prefix for backward compatibility.
+The source list of available icons can be found in joomla file `media/templates/administrator/atum/css/vendor/fontawesome-free.css`. For a visible representation of all icons with additional information see our [guide.joomla.org](https://guide.joomla.org/user-manual/templates/standard-icons)
 
-To display such an icon, you can use:
+## Fontawesome icons
+Fontawesome icons can be used for HTML in following forms:
 
-```php
-    <span class="icon-cancel" aria-hidden="true"></span> <?php echo Text::_('JCANCEL') ?> 
+```html
+<i style="font-size: 2rem;" class="fa fa-!name!"></i>
+<span class="fa fa-!name! "></span>
 ```
 
-The attribute aria-hidden="true" hides the icon from screen readers and improves accessibility. 
+The actual icon name fa-!name! class is accompanied by a prefix class like "fa ..". More below or see [FontAwesome 'classic' styles](https://docs.fontawesome.com/web/dig-deeper/styles)  
+The \<span\> element can also do the job but the preferred way is to use classes inside the \<i\> element.
+
+Add attribute ```aria-hidden="true"``` for hiding the icon from screen readers and improves accessibility. Use attribute ```style="font-size: 2rem;"``` or ```style="font-size: 48px;"``` for the size of the icon font.
+
+### Standard icons
+
+The Prefix part is ```fa``` which is short for ```fas``` which is short for ```fa-solid``` which can be used instead.
+
+The icon name part begins with ```fa-``` and the name. Example: 
+```php
+<i class="fa fa-envelope"></i>
+<i class="fa-solid fa-save" aria-hidden="true"></i> <?php echo Text::_('JSAVE') ?> 
+```
+
+### Brand icons
+
+The prefix part is ```fab``` which is short for ```fa-brands``` which can be used instead
+
+Example: 
+```php
+<i class="fab fa-joomla"></i>
+<i class="fa-brands fa-facebook" aria-hidden="true"></i> <?php echo 'Facebook' ?> 
+```
+
+## Icomoon replacement form / 'icon' parameter in code function calls
+
+For this set of icons, icon names from J3! (icomoon) were replaced (partly) by fontawesome icons. The icon itself is one of the fontawesome icons but the name may differ. Also this is a smaller subset with fewer icons. It is kept for compatibility with J!3 icomoon replacements. In joomla code there are functions which accept the icon name as parameter.
+
+### Direct Html use
+
+The class gets prefix "icon-" (e.g., "icon-calendar", "icon-file", etc.)
+
+Form: ```<i class="icon-name"></i>```. The "name" part has to be replaced by the icon name. 
+Add attribute aria-hidden="true" for hiding the icon from screen readers and improves accessibility. 
+
+Example: 
+```html
+<i class="icon-joomla" style="font-size: 48px;" ></i>
+<i class="icon-joomla"  aria-hidden="true" style="font-size: 48px;" ></i>
+```
+
+### Parameter in J! functions
+
+For example in HtmlView.php of a component the ToolBarHelper:: functions accept a icon name from this icon set.
+
+Example: 
+```html
+ToolBarHelper::title(Text::_('COM_EXAMPLE_TITLE'), 'envelope');
+```
+
+:::tip
+Instead of using an 'icon' name of the icon class (see above) a fontawesome icon may be used instead in following form. It is helpful when the required symbol is not available — or looks better.
+```html
+ToolBarHelper::title(Text::_('COM_EXAMPLE_TITLE'), 'none fa fa-camera-retro');
+```
+With 'none' given internally a 'icon-none' will be written into the HTML class and ' fa fa-camera-retro' will follow. 
+Attention: This could affect subsequent button icons whose CSS formatting is then redefined.
+:::
+
+## Using other icon sets
 
 In case you want to display other icons not included in the Joomla pack, you have several options, one of which is to use additional FontAwesome icons.
 This can be achieved in different ways depending on your needs:
 1. Using FontAwesome Kit - this is the easiest approach, but you should have an account on their site.
 2. Using self-hosted webfonts and additional CSS files from FontAwesome.
 3. Using self-hosted SVG and JS files - for a few icons, this way you will have some speed optimization.
-
-According to [How To Add Icons](https://docs.fontawesome.com/web/add-icons/how-to), the CSS classes are prefixed "fa-" as "fa-solid" or "fa-brands".
-The preferred way is to use classes inside the `<i>` element:
-
-```html
-    <i class="fa-solid fa-calendar" aria-hidden="true"></i>
-```
-
-But the span element can also do the job:
-
-```php
-    <span class="fa-solid fa-bomb" aria-hidden="true"></span> <?php echo Text::_('JSAVE') ?> 
-    <span class="fa-brands fa-facebook" aria-hidden="true"></span> <?php echo 'Facebook' ?> 
-```

--- a/versioned_docs/version-5.4/general-concepts/icons.md
+++ b/versioned_docs/version-5.4/general-concepts/icons.md
@@ -2,41 +2,89 @@
 title: Icons
 ---
 
-Icons
+Standard Joomla! Icons 
 =====
 
-Joomla uses free [FontAwesome](https://fontawesome.com/search) icons,
+## Overview
+Joomla uses the free [FontAwesome](https://fontawesome.com/search) icons,
 which are implemented as [CSS pseudo-elements](https://docs.fontawesome.com/web/add-icons/pseudo-elements)
 
-The list of available icons can be found in media/templates/administrator/atum/css/vendor/fontawesome-free.css
+Joomla implemented the free standard icons, brand icons and supports a subset "icon-..." to be compatible with J!3x and following versions
 
-The subset of FontAwesome icons used internally within Joomla is designated with the prefix "icon-" (e.g., "icon-calendar", "icon-file", etc.)
-This is a remnant of the old coding style of FontAwesome; its latest versions use the "fa-" prefix, but Joomla is keeping the old prefix for backward compatibility.
+The source list of available icons can be found in joomla file `media/templates/administrator/atum/css/vendor/fontawesome-free.css`. For a visible representation of all icons with additional information see our [guide.joomla.org](https://guide.joomla.org/user-manual/templates/standard-icons)
 
-To display such an icon, you can use:
+## Fontawesome icons
+Fontawesome icons can be used for HTML in following forms:
 
-```php
-    <span class="icon-cancel" aria-hidden="true"></span> <?php echo Text::_('JCANCEL') ?> 
+```html
+<i style="font-size: 2rem;" class="fa fa-!name!"></i>
+<span class="fa fa-!name! "></span>
 ```
 
-The attribute aria-hidden="true" hides the icon from screen readers and improves accessibility. 
+The actual icon name fa-!name! class is accompanied by a prefix class like "fa ..". More below or see [FontAwesome 'classic' styles](https://docs.fontawesome.com/web/dig-deeper/styles)  
+The \<span\> element can also do the job but the preferred way is to use classes inside the \<i\> element.
+
+Add attribute ```aria-hidden="true"``` for hiding the icon from screen readers and improves accessibility. Use attribute ```style="font-size: 2rem;"``` or ```style="font-size: 48px;"``` for the size of the icon font.
+
+### Standard icons
+
+The Prefix part is ```fa``` which is short for ```fas``` which is short for ```fa-solid``` which can be used instead.
+
+The icon name part begins with ```fa-``` and the name. Example: 
+```php
+<i class="fa fa-envelope"></i>
+<i class="fa-solid fa-save" aria-hidden="true"></i> <?php echo Text::_('JSAVE') ?> 
+```
+
+### Brand icons
+
+The prefix part is ```fab``` which is short for ```fa-brands``` which can be used instead
+
+Example: 
+```php
+<i class="fab fa-joomla"></i>
+<i class="fa-brands fa-facebook" aria-hidden="true"></i> <?php echo 'Facebook' ?> 
+```
+
+## Icomoon replacement form / 'icon' parameter in code function calls
+
+For this set of icons, icon names from J3! (icomoon) were replaced (partly) by fontawesome icons. The icon itself is one of the fontawesome icons but the name may differ. Also this is a smaller subset with fewer icons. It is kept for compatibility with J!3 icomoon replacements. In joomla code there are functions which accept the icon name as parameter.
+
+### Direct Html use
+
+The class gets prefix "icon-" (e.g., "icon-calendar", "icon-file", etc.)
+
+Form: ```<i class="icon-name"></i>```. The "name" part has to be replaced by the icon name. 
+Add attribute aria-hidden="true" for hiding the icon from screen readers and improves accessibility. 
+
+Example: 
+```html
+<i class="icon-joomla" style="font-size: 48px;" ></i>
+<i class="icon-joomla"  aria-hidden="true" style="font-size: 48px;" ></i>
+```
+
+### Parameter in J! functions
+
+For example in HtmlView.php of a component the ToolBarHelper:: functions accept a icon name from this icon set.
+
+Example: 
+```html
+ToolBarHelper::title(Text::_('COM_EXAMPLE_TITLE'), 'envelope');
+```
+
+:::tip
+Instead of using an 'icon' name of the icon class (see above) a fontawesome icon may be used instead in following form. It is helpful when the required symbol is not available — or looks better.
+```html
+ToolBarHelper::title(Text::_('COM_EXAMPLE_TITLE'), 'none fa fa-camera-retro');
+```
+With 'none' given internally a 'icon-none' will be written into the HTML class and ' fa fa-camera-retro' will follow. 
+Attention: This could affect subsequent button icons whose CSS formatting is then redefined.
+:::
+
+## Using other icon sets
 
 In case you want to display other icons not included in the Joomla pack, you have several options, one of which is to use additional FontAwesome icons.
 This can be achieved in different ways depending on your needs:
 1. Using FontAwesome Kit - this is the easiest approach, but you should have an account on their site.
 2. Using self-hosted webfonts and additional CSS files from FontAwesome.
 3. Using self-hosted SVG and JS files - for a few icons, this way you will have some speed optimization.
-
-According to [How To Add Icons](https://docs.fontawesome.com/web/add-icons/how-to), the CSS classes are prefixed "fa-" as "fa-solid" or "fa-brands".
-The preferred way is to use classes inside the `<i>` element:
-
-```html
-    <i class="fa-solid fa-calendar" aria-hidden="true"></i>
-```
-
-But the span element can also do the job:
-
-```php
-    <span class="fa-solid fa-bomb" aria-hidden="true"></span> <?php echo Text::_('JSAVE') ?> 
-    <span class="fa-brands fa-facebook" aria-hidden="true"></span> <?php echo 'Facebook' ?> 
-```

--- a/versioned_docs/version-6.1/general-concepts/icons.md
+++ b/versioned_docs/version-6.1/general-concepts/icons.md
@@ -2,41 +2,89 @@
 title: Icons
 ---
 
-Icons
+Standard Joomla! Icons 
 =====
 
-Joomla uses free [FontAwesome](https://fontawesome.com/search) icons,
+## Overview
+Joomla uses the free [FontAwesome](https://fontawesome.com/search) icons,
 which are implemented as [CSS pseudo-elements](https://docs.fontawesome.com/web/add-icons/pseudo-elements)
 
-The list of available icons can be found in media/templates/administrator/atum/css/vendor/fontawesome-free.css
+Joomla implemented the free standard icons, brand icons and supports a subset "icon-..." to be compatible with J!3x and following versions
 
-The subset of FontAwesome icons used internally within Joomla is designated with the prefix "icon-" (e.g., "icon-calendar", "icon-file", etc.)
-This is a remnant of the old coding style of FontAwesome; its latest versions use the "fa-" prefix, but Joomla is keeping the old prefix for backward compatibility.
+The source list of available icons can be found in joomla file `media/templates/administrator/atum/css/vendor/fontawesome-free.css`. For a visible representation of all icons with additional information see our [guide.joomla.org](https://guide.joomla.org/user-manual/templates/standard-icons)
 
-To display such an icon, you can use:
+## Fontawesome icons
+Fontawesome icons can be used for HTML in following forms:
 
-```php
-    <span class="icon-cancel" aria-hidden="true"></span> <?php echo Text::_('JCANCEL') ?> 
+```html
+<i style="font-size: 2rem;" class="fa fa-!name!"></i>
+<span class="fa fa-!name! "></span>
 ```
 
-The attribute aria-hidden="true" hides the icon from screen readers and improves accessibility. 
+The actual icon name fa-!name! class is accompanied by a prefix class like "fa ..". More below or see [FontAwesome 'classic' styles](https://docs.fontawesome.com/web/dig-deeper/styles)  
+The \<span\> element can also do the job but the preferred way is to use classes inside the \<i\> element.
+
+Add attribute ```aria-hidden="true"``` for hiding the icon from screen readers and improves accessibility. Use attribute ```style="font-size: 2rem;"``` or ```style="font-size: 48px;"``` for the size of the icon font.
+
+### Standard icons
+
+The Prefix part is ```fa``` which is short for ```fas``` which is short for ```fa-solid``` which can be used instead.
+
+The icon name part begins with ```fa-``` and the name. Example: 
+```php
+<i class="fa fa-envelope"></i>
+<i class="fa-solid fa-save" aria-hidden="true"></i> <?php echo Text::_('JSAVE') ?> 
+```
+
+### Brand icons
+
+The prefix part is ```fab``` which is short for ```fa-brands``` which can be used instead
+
+Example: 
+```php
+<i class="fab fa-joomla"></i>
+<i class="fa-brands fa-facebook" aria-hidden="true"></i> <?php echo 'Facebook' ?> 
+```
+
+## Icomoon replacement form / 'icon' parameter in code function calls
+
+For this set of icons, icon names from J3! (icomoon) were replaced (partly) by fontawesome icons. The icon itself is one of the fontawesome icons but the name may differ. Also this is a smaller subset with fewer icons. It is kept for compatibility with J!3 icomoon replacements. In joomla code there are functions which accept the icon name as parameter.
+
+### Direct Html use
+
+The class gets prefix "icon-" (e.g., "icon-calendar", "icon-file", etc.)
+
+Form: ```<i class="icon-name"></i>```. The "name" part has to be replaced by the icon name. 
+Add attribute aria-hidden="true" for hiding the icon from screen readers and improves accessibility. 
+
+Example: 
+```html
+<i class="icon-joomla" style="font-size: 48px;" ></i>
+<i class="icon-joomla"  aria-hidden="true" style="font-size: 48px;" ></i>
+```
+
+### Parameter in J! functions
+
+For example in HtmlView.php of a component the ToolBarHelper:: functions accept a icon name from this icon set.
+
+Example: 
+```html
+ToolBarHelper::title(Text::_('COM_EXAMPLE_TITLE'), 'envelope');
+```
+
+:::tip
+Instead of using an 'icon' name of the icon class (see above) a fontawesome icon may be used instead in following form. It is helpful when the required symbol is not available — or looks better.
+```html
+ToolBarHelper::title(Text::_('COM_EXAMPLE_TITLE'), 'none fa fa-camera-retro');
+```
+With 'none' given internally a 'icon-none' will be written into the HTML class and ' fa fa-camera-retro' will follow. 
+Attention: This could affect subsequent button icons whose CSS formatting is then redefined.
+:::
+
+## Using other icon sets
 
 In case you want to display other icons not included in the Joomla pack, you have several options, one of which is to use additional FontAwesome icons.
 This can be achieved in different ways depending on your needs:
 1. Using FontAwesome Kit - this is the easiest approach, but you should have an account on their site.
 2. Using self-hosted webfonts and additional CSS files from FontAwesome.
 3. Using self-hosted SVG and JS files - for a few icons, this way you will have some speed optimization.
-
-According to [How To Add Icons](https://docs.fontawesome.com/web/add-icons/how-to), the CSS classes are prefixed "fa-" as "fa-solid" or "fa-brands".
-The preferred way is to use classes inside the `<i>` element:
-
-```html
-    <i class="fa-solid fa-calendar" aria-hidden="true"></i>
-```
-
-But the span element can also do the job:
-
-```php
-    <span class="fa-solid fa-bomb" aria-hidden="true"></span> <?php echo Text::_('JSAVE') ?> 
-    <span class="fa-brands fa-facebook" aria-hidden="true"></span> <?php echo 'Facebook' ?> 
-```


### PR DESCRIPTION
This pull request improves the  documentation for Joomla standard icons.
* Added overview
* Each icon type has its own section
* Link to guide.joomla.org icon list [guide.joomla.org](https://guide.joomla.org/user-manual/templates/standard-icons?highlight=WyJpY29ucyJd)
* Better IcoMoon icon replacement documentation

> This is my first article for manual.joomla.org. Please support me with style or other needed fixes for release of the pull request 