### PR TITLE
[6.2] Build Script Changes + Patch-Tester

### DIFF
--- a/docs/testing/manually/patch-tester.md
+++ b/docs/testing/manually/patch-tester.md
@@ -36,7 +36,9 @@ It is worth spending some time on examination of the list. For example the first
 - The coloured labels contain information about the pull request, such as *bug* or *Feature* and whether a test has an *NPM Resource Changed*. A list of labels can be found in the [Labels page](https://github.com/joomla/joomla-cms/labels) of the `joomla-cms` GitHub repository.
 - The **Branch** shows which Joomla branch the pull request was created for. You will see all pull requests for all branches in the list. Some pull requests may require testing against a specific branch but this is not always so.
 - The **Apply Patch** button applies the patch created in the pull request to your test installation. This button is initially absent for patches that involve an *NPM Resource Change*, *Composer Dependency Change* or are *RTC*.
-    - Advanced users: to enable the missing *Apply Patch* buttons set **Advanced Mode** to **Yes** in the *Options* and then use the command line to run `npm ci` or `npm run build:css` if the change only affects CSS files or `npm run build:js` if the change only affects JavaScript files. 
+    - Advanced users: to enable the missing *Apply Patch* buttons set **Advanced Mode** to **Yes** in the *Options* and then use the command line to run `npm ci` after applying the patch. If the change only affects CSS or JavaScript source files (no new packages):
+        - **Joomla 6.2+**: `npm run build -- -n <extension>` to rebuild a specific extension (run `npm run builders-list` to find the extension name), or `npm run build -- --all` to rebuild everything
+        - **Joomla up to 6.1**: `npm run build:css` (CSS only) or `npm run build:js` (JS only)
 - Follow the Test Instructions in the Issue Tracker to test the patch. When finished, *Revert* the patch.
     - Advanced users: rerun `npm ci` if the patch involved an NPM Resource Change.
 
@@ -73,7 +75,7 @@ When you have looked through the list of issues and seen something that you thin
 - Read the Summary of Changes, Testing Instructions and any Comments.
     - It may be that the the pull request does what the author intended but more experienced developers see that it uses the wrong approach or will cause future problems. They may ask for changes or reject it completely. Defer testing until any comments have been satisfied!
 - Have a look at the Diff to see how many files are changed and how extensive the changes are.
-- In the Patch Tester apply the patch and see whether it does what it is supposed to do according to the Testing Instructions. Remember the `npm ci` command if the patch changes CSS or JavaScript.
+- In the Patch Tester apply the patch and see whether it does what it is supposed to do according to the Testing Instructions. Remember to run `npm ci` if the patch involves an NPM Resource Change, or the appropriate build command if only CSS/JavaScript source files changed (see the note above for the correct command for your Joomla version).
 - If you are satisfied that the pull request does what it is supposed to do and does not appear to have side effects go back to the Joomla Issue Tracker page.
     - Select the **Test This** button. A form opens for you to enter your test result.
 

--- a/docs/testing/manually/patch-tester.md
+++ b/docs/testing/manually/patch-tester.md
@@ -36,7 +36,7 @@ It is worth spending some time on examination of the list. For example the first
 - The coloured labels contain information about the pull request, such as *bug* or *Feature* and whether a test has an *NPM Resource Changed*. A list of labels can be found in the [Labels page](https://github.com/joomla/joomla-cms/labels) of the `joomla-cms` GitHub repository.
 - The **Branch** shows which Joomla branch the pull request was created for. You will see all pull requests for all branches in the list. Some pull requests may require testing against a specific branch but this is not always so.
 - The **Apply Patch** button applies the patch created in the pull request to your test installation. This button is initially absent for patches that involve an *NPM Resource Change*, *Composer Dependency Change* or are *RTC*.
-    - Advanced users: to enable the missing *Apply Patch* buttons set **Advanced Mode** to **Yes** in the *Options* and then use the command line to run `npm ci` after applying the patch. If the change only affects CSS or JavaScript source files (no new packages):
+    - Advanced users: to enable the missing *Apply Patch* buttons set **Advanced Mode** to **Yes** in the *Options* and then use the command line to run `npm ci` after applying the patch or if the change only affects CSS or JavaScript source files (no new packages):
         - **Joomla 6.2+**: `npm run build -- -n <extension>` to rebuild a specific extension (run `npm run builders-list` to find the extension name), or `npm run build -- --all` to rebuild everything
         - **Joomla up to 6.1**: `npm run build:css` (CSS only) or `npm run build:js` (JS only)
 - Follow the Test Instructions in the Issue Tracker to test the patch. When finished, *Revert* the patch.

--- a/updates/61-62/new-features.md
+++ b/updates/61-62/new-features.md
@@ -19,7 +19,7 @@ The Joomla asset build pipeline has been completely overhauled. The old monolith
 Source files previously located in `build/media_source/` have been moved to `/media_source/` at the repository root for consistent relative includes.
 Vendor library build configuration is now centralized in `build/build-modules-js/settings.json`.
 
-- **PR**: [#46879](https://github.com/joomla/joomla-cms/pull/46879) by **Fedik**
+- **PR**: [#46879](https://github.com/joomla/joomla-cms/pull/46879)
 - **PR**: [#47815](https://github.com/joomla/joomla-cms/pull/47815)
 - **What changed**: Developers can compile or watch a single extension without triggering a full rebuild.
 With the `--all` flag it is possible to watch all builders at once.

--- a/updates/61-62/new-features.md
+++ b/updates/61-62/new-features.md
@@ -12,6 +12,109 @@ New Features
 All the new features that have been added to this version.
 Any changes in best practice.
 
-:::tip[Reader Note]
-No new features have been introduced in Joomla 6.2 yet
-:::
+## New modular build script system
+
+The Joomla asset build pipeline has been completely overhauled. The old monolithic build scripts (`compilecss.mjs`, `compilejs.mjs`, `compress.mjs`) have been replaced with a modular, per-extension builder architecture under `build/build-modules-js/`.
+
+Source files previously located in `build/media_source/` have been moved to `/media_source/` at the repository root for consistent relative includes.
+Vendor library build configuration is now centralized in `build/build-modules-js/settings.json`.
+
+- **PR**: [#46879](https://github.com/joomla/joomla-cms/pull/46879) by **Fedik**
+- **PR**: [#47815](https://github.com/joomla/joomla-cms/pull/47815)
+- **What changed**: Developers can compile or watch a single extension without triggering a full rebuild.
+With the `--all` flag it is possible to watch all builders at once.
+A new `builders-list` command shows all registered builders.
+- **Usage**:
+  ```bash
+  # List all available builders
+  npm run builders-list
+
+  # Build a single extension
+  npm run build -- -n com_content
+
+  # Build only CSS for a specific template
+  npm run build -- -n templates/administrator/atum -t css
+
+  # Watch multiple extensions
+  npm run watch -- -n com_content,com_categories
+
+  # Watch all extensions at once
+  npm run watch -- --all
+
+  # Build/watch with development settings (no minification)
+  npm run build:dev -- -n com_content
+  npm run watch:dev -- -n com_content
+  ```
+- **Impact**: Developers contributing frontend assets no longer need to run a full rebuild. Targeting individual extensions significantly speeds up the development workflow.
+With the new `builders-list` command, it is easy to discover all registered extension names for use with `-n`.
+
+---
+
+### Registering a new extension for building
+
+To include a new extension in the build pipeline, the name must be added to `build/build-modules-js/builders-registry.mjs`:
+
+```js
+export const builders = [
+  // ... existing entries
+  'new_extension', // resolves to media_source/new_extension/
+];
+```
+
+The name must match the subfolder under `media_source/`. If no `builder.mjs` file is found there, `DefaultModuleBuilder` is used automatically, which handles standard CSS/JS compilation.
+
+---
+
+### Adding a custom builder
+
+For extensions that need non-standard build steps, the developer can create a `media_source/my_extension/builder.mjs` extending `DefaultModuleBuilder`:
+
+```js
+import DefaultModuleBuilder from '../../build/build-modules-js/builder/default-module-builder.mjs';
+
+export default class MyExtensionBuilder extends DefaultModuleBuilder {
+  async copy() {
+    await super.copy();
+    // add custom copy logic here
+  }
+
+  async js() {
+    // custom JavaScript bundling/processing
+  }
+}
+```
+
+The extension name must be added to `builders-registry.mjs` as shown above. The builder factory automatically detects and loads `builder.mjs` when present.
+
+---
+
+### Adding a third-party vendor package via settings.json
+
+For npm packages that should be copied to `media/vendor/`, add an entry to `build/build-modules-js/settings.json` under `settings.vendors`:
+
+```json
+{
+  "name": "my-library",
+  "js": {
+    "node_modules/my-library/dist/my-library.min.js": "media/vendor/my-library/js/my-library.min.js"
+  },
+  "css": {
+    "node_modules/my-library/dist/my-library.min.css": "media/vendor/my-library/css/my-library.min.css"
+  },
+  "provideAssets": [
+    {
+      "name": "my-library",
+      "type": "script",
+      "uri": "vendor/my-library/js/my-library.min.js",
+      "dependencies": []
+    }
+  ],
+  "licenseFilename": "LICENSE"
+}
+```
+
+To apply the changes, the `vendor` builder must be run once to copy the new files:
+
+```bash
+npm run build -- -n vendor
+```

--- a/updates/61-62/new-features.md
+++ b/updates/61-62/new-features.md
@@ -16,7 +16,7 @@ Any changes in best practice.
 
 The Joomla asset build pipeline has been completely overhauled. The old monolithic build scripts (`compilecss.mjs`, `compilejs.mjs`, `compress.mjs`) have been replaced with a modular, per-extension builder architecture under `build/build-modules-js/`.
 
-Source files previously located in `build/media_source/` have been moved to `/media_source/` at the repository root for consistent relative includes.
+Source files previously located in `build/media_source/` have been moved to `media_source/` at the repository root for consistent relative includes.
 Vendor library build configuration is now centralized in `build/build-modules-js/settings.json`.
 
 - **PR**: [#46879](https://github.com/joomla/joomla-cms/pull/46879)


### PR DESCRIPTION
This pull request updates the documentation to reflect the new modular build system introduced in Joomla 6.2. The changes provide detailed instructions for developers on using the new build scripts, updating the asset build workflow, and registering new extensions or vendor packages. It also updates manual testing instructions with the Patch Tester to align with the new build process.