### PR TITLE
Remove ReshapeArgumentsAware trait for named arguments

### DIFF
--- a/updates/64-70/removed-backward-incompatibility.md
+++ b/updates/64-70/removed-backward-incompatibility.md
@@ -433,7 +433,7 @@ $value = $app->getInput();
 - Description: The `ReshapeArgumentsAware` trait got removed as it's intention was to make the bridge to named arguments. So named arguments should always be used instead of the argument list as the order can't be guaranteed anymore:
 ```php
 // Old:
-[$foo, $bar] = array_values($event->getArbuements());
+[$foo, $bar] = array_values($event->getArguments());
 
 // New:
 $foo = $event->getArgument('foo');

--- a/updates/64-70/removed-backward-incompatibility.md
+++ b/updates/64-70/removed-backward-incompatibility.md
@@ -426,3 +426,16 @@ Factory::getApplication()->bootComponent('messages')->getMVCFactory()
 Factory::getContainer()->get(ApiRouter::class);
 $value = $app->getInput();
 ```
+
+## ReshapeArgumentsAware trait got removed
+- PR: https://github.com/joomla/joomla-cms/pull/47459
+- File: /libraries/src/Event/ReshapeArgumentsAware.php
+- Description: The `ReshapeArgumentsAware` trait got removed as it's intention was to make the bridge to named arguments. So named arguments should always be used instead of the argument list as the order can't be guaranteed anymore:
+```php
+// Old:
+[$foo, $bar] = array_values($event->getArbuements());
+
+// New:
+$foo = $event->getArgument('foo');
+$bar = $event->getArgument('bar');
+```


### PR DESCRIPTION
Removed the ReshapeArgumentsAware trait to enforce the use of named arguments, providing updated usage examples.
https://github.com/joomla/joomla-cms/pull/47459