### PR TITLE
Document the concrete event classes for seven core events

### DIFF
--- a/updates/64-70/new-features.md
+++ b/updates/64-70/new-features.md
@@ -11,3 +11,76 @@ New Features
 
 All the new features that have been added to this version.
 Any changes in best practice.
+
+
+## Concrete event classes for seven core events
+- PR: https://github.com/joomla/joomla-cms/pull/XXXXX
+- Files:
+  - /libraries/src/Event/Application/BuildAdministratorLoginUrlEvent.php
+  - /libraries/src/Event/Finder/IndexAfterDeleteEvent.php
+  - /libraries/src/Event/Finder/IndexAfterIndexEvent.php
+  - /libraries/src/Event/Finder/IndexAfterPurgeEvent.php
+  - /libraries/src/Event/Finder/SortOrderFieldsEvent.php
+  - /libraries/src/Event/Mail/BeforeTagsRenderingEvent.php
+  - /libraries/src/Event/Module/GetStatsEvent.php
+  - /libraries/src/Event/CoreEventAware.php
+- Description: Seven core events were still dispatched as the generic `Joomla\Event\Event` with positional arguments, so a listener could only reach their data through `$event->getArgument(0)`. Each now has a concrete event class, registered in `CoreEventAware`, with named arguments and typed getters.
+
+  | Event | Class | Arguments |
+  | --- | --- | --- |
+  | `onFinderIndexAfterIndex` | `Joomla\CMS\Event\Finder\IndexAfterIndexEvent` | `subject` (`Result`), `linkId` |
+  | `onFinderIndexAfterDelete` | `Joomla\CMS\Event\Finder\IndexAfterDeleteEvent` | `linkId` or `itemId` |
+  | `onFinderIndexAfterPurge` | `Joomla\CMS\Event\Finder\IndexAfterPurgeEvent` | none |
+  | `onFinderSortOrderFields` | `Joomla\CMS\Event\Finder\SortOrderFieldsEvent` | `sortOrderFields` |
+  | `onMailBeforeTagsRendering` | `Joomla\CMS\Event\Mail\BeforeTagsRenderingEvent` | `templateId`, `subject` |
+  | `onGetStats` | `Joomla\CMS\Event\Module\GetStatsEvent` | `context` |
+  | `onBuildAdministratorLoginURL` | `Joomla\CMS\Event\Application\BuildAdministratorLoginUrlEvent` | `subject` (`Uri`) |
+
+  Read the arguments through the getters instead of by position:
+```php
+// Old:
+public function onFinderIndexAfterIndex($event)
+{
+    $item   = $event->getArgument(0);
+    $linkId = $event->getArgument(1);
+}
+
+// New:
+public function onFinderIndexAfterIndex(IndexAfterIndexEvent $event): void
+{
+    $item   = $event->getItem();
+    $linkId = $event->getLinkId();
+}
+```
+  `onFinderIndexAfterDelete` carries a `linkId` when the indexer removed a link, and an `itemId` when an
+  indexer adapter was asked to remove a source item that had no link. Exactly one of the two is set, so
+  check both:
+```php
+$id = $event->getLinkId() ?? $event->getItemId();
+```
+
+## Plugins declaring `DispatcherAwareInterface` receive the dispatcher
+- PR: https://github.com/joomla/joomla-cms/pull/XXXXX
+- Files:
+  - /libraries/src/Plugin/PluginHelper.php
+- Description: `CMSPlugin::getDispatcher()` and `CMSPlugin::setDispatcher()` are deprecated, and the notice asks plugins that need a dispatcher to implement `DispatcherAwareInterface` themselves. Until now that did not work for plugins implementing `SubscriberInterface`: `PluginHelper::import()` registered them with `$dispatcher->addSubscriber($plugin)` and never called `setDispatcher()`, so `$this->getDispatcher()` threw an `UnexpectedValueException`.
+
+  `PluginHelper::import()` now injects the dispatcher into plugins which declare `DispatcherAwareInterface` themselves, before registering their listeners. Plugins which only inherit it from `CMSPlugin` are unchanged, so no additional deprecation notices are emitted.
+
+  A plugin which dispatches its own events should declare the interface and use the trait:
+```php
+// New:
+final class MyPlugin extends CMSPlugin implements SubscriberInterface, DispatcherAwareInterface
+{
+    use DispatcherAwareTrait;
+
+    private function fire(): void
+    {
+        // The dispatcher its own listeners were registered on, not necessarily the application one.
+        $this->getDispatcher()->dispatch('onMyEvent', new MyEvent('onMyEvent', ['context' => 'com_example']));
+    }
+}
+```
+  This matters when a caller passes its own dispatcher to `PluginHelper::importPlugin()`, which several
+  core controllers do. Listeners are registered on that dispatcher, so events fired on any other one
+  reach nobody.

--- a/updates/64-70/new-features.md
+++ b/updates/64-70/new-features.md
@@ -14,7 +14,7 @@ Any changes in best practice.
 
 
 ## Concrete event classes for seven core events
-- PR: https://github.com/joomla/joomla-cms/pull/XXXXX
+- PR: https://github.com/joomla/joomla-cms/pull/48382
 - Files:
   - /libraries/src/Event/Application/BuildAdministratorLoginUrlEvent.php
   - /libraries/src/Event/Finder/IndexAfterDeleteEvent.php
@@ -60,7 +60,7 @@ $id = $event->getLinkId() ?? $event->getItemId();
 ```
 
 ## Plugins declaring `DispatcherAwareInterface` receive the dispatcher
-- PR: https://github.com/joomla/joomla-cms/pull/XXXXX
+- PR: https://github.com/joomla/joomla-cms/pull/48382
 - Files:
   - /libraries/src/Plugin/PluginHelper.php
 - Description: `CMSPlugin::getDispatcher()` and `CMSPlugin::setDispatcher()` are deprecated, and the notice asks plugins that need a dispatcher to implement `DispatcherAwareInterface` themselves. Until now that did not work for plugins implementing `SubscriberInterface`: `PluginHelper::import()` registered them with `$dispatcher->addSubscriber($plugin)` and never called `setDispatcher()`, so `$this->getDispatcher()` threw an `UnexpectedValueException`.

--- a/updates/64-70/removed-backward-incompatibility.md
+++ b/updates/64-70/removed-backward-incompatibility.md
@@ -438,3 +438,61 @@ $value = $app->getInput();
   Users which hasn't logged in since Joomla! 3.2.1 will need to use the password reset method since the password can not longer be validated.
 :::
 
+
+## Positional and by-reference arguments removed from seven core events
+- PR: https://github.com/joomla/joomla-cms/pull/XXXXX
+- Files:
+  - /administrator/components/com_finder/src/Indexer/Adapter.php
+  - /administrator/components/com_finder/src/Indexer/DebugAdapter.php
+  - /administrator/components/com_finder/src/Indexer/Indexer.php
+  - /administrator/components/com_finder/src/Model/IndexModel.php
+  - /administrator/components/com_mails/src/Helper/MailsHelper.php
+  - /administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
+  - /components/com_finder/src/Model/SearchModel.php
+  - /modules/mod_stats/src/Helper/StatsHelper.php
+  - /plugins/task/updatenotification/src/Extension/UpdateNotification.php
+- Description: The events `onFinderIndexAfterIndex`, `onFinderIndexAfterDelete`, `onFinderIndexAfterPurge`, `onFinderSortOrderFields`, `onMailBeforeTagsRendering`, `onGetStats` and `onBuildAdministratorLoginURL` are no longer dispatched with a positional argument array. Each now uses a concrete event class with named arguments, described under [New Features](new-features.md). Plugins using `CMSPlugin` legacy listeners are not affected, because the arguments are declared in the order the positional arrays used. Plugins implementing `SubscriberInterface` have to change in three ways.
+
+  Numeric argument access no longer resolves:
+```php
+// Old:
+public function onGetStats(Event $event): void
+{
+    $context = $event->getArgument(0);
+}
+
+// New:
+public function onGetStats(GetStatsEvent $event): void
+{
+    $context = $event->getContext();
+}
+```
+  Three of the events passed an argument by reference. They no longer do, and a listener which changes
+  the value has to hand it back to the event with `updateSortOrderFields()`, `updateMail()` or
+  `updateUri()`. Modifying an object in place still works, because the event holds the same instance:
+```php
+// Old:
+public function onFinderSortOrderFields(Event $event): void
+{
+    $fields   = $event->getArgument(0);
+    $fields[] = $myField;
+
+    $event->setArgument(0, $fields);
+}
+
+// New:
+public function onFinderSortOrderFields(SortOrderFieldsEvent $event): void
+{
+    $fields   = $event->getSortOrderFields();
+    $fields[] = $myField;
+
+    $event->updateSortOrderFields($fields);
+}
+```
+  `onGetStats` results are now type checked. A listener must return an array of rows, or add one with
+  `addResult()`. Returning anything else previously produced a PHP warning and the value was skipped,
+  and now throws an `InvalidArgumentException`.
+
+  `onFinderIndexAfterIndex` type checks its `subject` argument against
+  `Joomla\Component\Finder\Administrator\Indexer\Result`. An indexer adapter which passed a plain
+  `stdClass` to `Indexer::index()` now causes a `TypeError`.


### PR DESCRIPTION
Seven core events were still dispatched as the generic Joomla\Event\Event with positional arguments. They now have concrete event classes with named arguments, so document what listeners have to change.

Under New Features: the seven new classes and their arguments, and the fact that PluginHelper::import() now injects the dispatcher into plugins which declare DispatcherAwareInterface themselves.

Under Removed and Backward Incompatibility: numeric argument access, the three arguments which are no longer passed by reference, the array type check on onGetStats results, and the Result type check on onFinderIndexAfterIndex.